### PR TITLE
Remove encode_data side effects on input dict

### DIFF
--- a/parsley/parsley.py
+++ b/parsley/parsley.py
@@ -113,8 +113,8 @@ def format_can_message(msg_sid: int, msg_data: List[int]) -> Tuple[bytes, bytes]
 
 # given a dictionary of CAN message data, return the CAN message bits
 def encode_data(parsed_data: dict) -> Tuple[int, List[int]]:
-    msg_type = parsed_data.pop('msg_type')
-    board_id = parsed_data.pop('board_id')
+    msg_type = parsed_data['msg_type']
+    board_id = parsed_data['board_id']
 
     bit_str = BitString()
     bit_str.push(*MESSAGE_TYPE.encode(msg_type))


### PR DESCRIPTION
Currently, when encode_data is run by passing in a dict, it pops the elements rather than reading their values directly. 

This means that if it's passed a dictionary as a reference, it will have side effects on the dictionary itself, while it doesn't have to (which causes problems when trying to fake data for testing, for example). 

It's been fixed by replacing .pop with reading directly from the dictionary, which should succeed in the same scenarios, while not removing the element, and only fail if the index is not found, where they'll both throw an IndexError.

**How did I test it:**
- Ran parsley with the fix on simulated data and saw that it still encoded the data exactly the same

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/parsley/6)
<!-- Reviewable:end -->
