### PR TITLE
Changed endianess of state_est_data

### DIFF
--- a/parsley/message_definitions.py
+++ b/parsley/message_definitions.py
@@ -74,7 +74,7 @@ MESSAGES = {
     'GPS_INFO':             [BOARD_ID, TIMESTAMP_3, Numeric('num_sats', 8), Numeric('quality', 8)],
 
     'FILL_LVL':             [BOARD_ID, TIMESTAMP_3, Numeric('level', 8), Enum('direction', 8, mt.fill_direction)],
-    'STATE_EST_DATA':       [BOARD_ID, TIMESTAMP_3, Floating('data', big_endian=False), Enum('state_id', 8, mt.state_id)],
+    'STATE_EST_DATA':       [BOARD_ID, TIMESTAMP_3, Floating('data'), Enum('state_id', 8, mt.state_id)],
 
     'LEDS_ON':              [BOARD_ID],
     'LEDS_OFF':             [BOARD_ID]

--- a/parsley/message_definitions.py
+++ b/parsley/message_definitions.py
@@ -74,7 +74,7 @@ MESSAGES = {
     'GPS_INFO':             [BOARD_ID, TIMESTAMP_3, Numeric('num_sats', 8), Numeric('quality', 8)],
 
     'FILL_LVL':             [BOARD_ID, TIMESTAMP_3, Numeric('level', 8), Enum('direction', 8, mt.fill_direction)],
-    'STATE_EST_DATA':       [BOARD_ID, TIMESTAMP_3, Floating('data'), Enum('state_id', 8, mt.state_id)],
+    'STATE_EST_DATA':       [BOARD_ID, TIMESTAMP_3, Floating('data', big_endian=False), Enum('state_id', 8, mt.state_id)],
 
     'LEDS_ON':              [BOARD_ID],
     'LEDS_OFF':             [BOARD_ID]


### PR DESCRIPTION
Floats are stored, at least on the STM32H733, as little endian. State estimation message format has been updated to reflect this

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/parsley/11)
<!-- Reviewable:end -->
