### PR TITLE
Fix unit test to work with the new function name support (Commented s…

### DIFF
--- a/tests/test_can_messages.py
+++ b/tests/test_can_messages.py
@@ -47,7 +47,7 @@ class TestCANMessage:
     def test_reset_cmd(self, bit_str3):
         bit_str3.push(*Enum('board_id', 8, mt.board_id).encode('ANY'))
         res = parsley.parse_fields(bit_str3, CAN_MESSAGE.get_fields('RESET_CMD')[1:])
-        assert res['board_id'] == 'ANY'
+        assert res['reset_board_id'] == 'ANY'
 
     def test_debug_msg(self, bit_str3):
         bit_str3.push(*Numeric('level', 4).encode(6))
@@ -98,26 +98,26 @@ class TestCANMessage:
         assert res['status'] == 'E_NOMINAL'
 
     def test_board_status_current(self, bit_str3):
-        bit_str3.push(*Enum('status', 8, mt.board_status).encode('E_BUS_OVER_CURRENT'))
+        bit_str3.push(*Enum('status', 8, mt.board_status).encode('E_5V_OVER_CURRENT'))
         bit_str3.push(*Numeric('current', 16).encode(12345))
         res = parsley.parse_fields(bit_str3, CAN_MESSAGE.get_fields('GENERAL_BOARD_STATUS')[1:])
-        assert res['status'] == 'E_BUS_OVER_CURRENT'
+        assert res['status'] == 'E_5V_OVER_CURRENT'
         assert res['current'] == 12345
 
     def test_board_status_voltage(self, bit_str3):
-        bit_str3.push(*Enum('status', 8, mt.board_status).encode('E_BUS_UNDER_VOLTAGE'))
+        bit_str3.push(*Enum('status', 8, mt.board_status).encode('E_5V_UNDER_VOLTAGE'))
         bit_str3.push(*Numeric('voltage', 16).encode(54321))
         res = parsley.parse_fields(bit_str3, CAN_MESSAGE.get_fields('GENERAL_BOARD_STATUS')[1:])
-        assert res['status'] == 'E_BUS_UNDER_VOLTAGE'
+        assert res['status'] == 'E_5V_UNDER_VOLTAGE'
         assert res['voltage'] == 54321
 
-    def test_board_status_dead(self, bit_str3):
-        bit_str3.push(*Enum('status', 8, mt.board_status).encode('E_BOARD_FEARED_DEAD'))
-        bit_str3.push(*Enum('board_id', 8, mt.board_id).encode('KALMAN'))
-        res = parsley.parse_fields(bit_str3, CAN_MESSAGE.get_fields('GENERAL_BOARD_STATUS')[1:])
-        print(res)
-        assert res['status'] == 'E_BOARD_FEARED_DEAD'
-        assert res['board_id'] == 'KALMAN'
+    # def test_board_status_dead(self, bit_str3):
+    #     bit_str3.push(*Enum('status', 8, mt.board_status).encode('E_BOARD_FEARED_DEAD'))
+    #     bit_str3.push(*Enum('board_id', 8, mt.board_id).encode('KALMAN'))
+    #     res = parsley.parse_fields(bit_str3, CAN_MESSAGE.get_fields('GENERAL_BOARD_STATUS')[1:])
+    #     print(res)
+    #     assert res['status'] == 'E_BOARD_FEARED_DEAD'
+    #     assert res['board_id'] == 'KALMAN'
 
     def test_board_status_quiet(self, bit_str3):
         bit_str3.push(*Enum('status', 8, mt.board_status).encode('E_NO_CAN_TRAFFIC'))
@@ -260,12 +260,12 @@ class TestCANMessage:
         assert res['level'] == 9
         assert res['direction'] == 'FILLING'
 
-    def test_radi_value(self, bit_str3):
-        bit_str3.push(*Numeric('radi_board', 8).encode(1))
-        bit_str3.push(*Numeric('radi', 16).encode(500))
-        res = parsley.parse_fields(bit_str3, CAN_MESSAGE.get_fields('RADI_VALUE')[1:])
-        assert res['radi_board'] == 1
-        assert res['radi'] == 500
+    # def test_radi_value(self, bit_str3):
+    #     bit_str3.push(*Numeric('radi_board', 8).encode(1))
+    #     bit_str3.push(*Numeric('radi', 16).encode(500))
+    #     res = parsley.parse_fields(bit_str3, CAN_MESSAGE.get_fields('RADI_VALUE')[1:])
+    #     assert res['radi_board'] == 1
+    #     assert res['radi'] == 500
 
     def test_leds_on(self):
         # LED_ON message has no message body

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -57,11 +57,11 @@ class TestASCII:
 class TestEnum:
     def test_enum(self):
         enum = Enum('enum', 8, mt.board_id)
-        (data, length) = enum.encode('ACTUATOR_INJ')
+        (data, length) = enum.encode('DAQ')
         assert data == b'\x01'
         assert length == 8
         data = enum.decode(b'\x13')
-        assert data == 'USB'
+        assert data == 'CAMERA_3'
 
     def test_enum_decode_encode(self):
         map = { 'a': 1, 'b': 10, 'c': 100 }

--- a/tests/test_parsley.py
+++ b/tests/test_parsley.py
@@ -9,9 +9,9 @@ import test_utils as tu
 
 class TestParsley:
     def test_parse(self):
-        msg_sid = tu.create_msg_sid_from_strings('GENERAL_BOARD_STATUS', 'RLCS')
+        msg_sid = tu.create_msg_sid_from_strings('GENERAL_BOARD_STATUS', 'USB')
         """
-                     |----| => ___1 0100 = 0x14 = RLCS
+                     |----| => ___1 0100 = 0x14 = USB
         ____ _101 0011 0100
               |-----| => _101 0010 = 0x52 = GENERAL_BARD_STATUS
         """
@@ -22,11 +22,11 @@ class TestParsley:
         bit_str.push(*Enum('status', 8, mt.board_status).encode('E_SENSOR')) # 0x10
         bit_str.push(*Enum('sensor_id', 8, mt.sensor_id).encode('SENSOR_PRESSURE_PNEUMATICS')) # 0x07
         msg_data = bit_str.pop(40)
-        assert msg_data == b'\x00\x00\x05\x10\x07'
+        assert msg_data == b'\x00\x00\x05\x12\n'
 
         res = parsley.parse(msg_sid, msg_data)
         expected_res = {
-            'board_id': 'RLCS',
+            'board_id': 'USB',
             'msg_type': 'GENERAL_BOARD_STATUS',
             'data': {
                 'time': 0.005,
@@ -43,7 +43,7 @@ class TestParsley:
         ____ _001 1000 1011
               |-----| => _001 1000 = 0x18 = DEBUG_MSG
         """
-        assert msg_sid == b'\x01\x8B'
+        assert msg_sid == b'\x01\x90'
 
         bit_str = BitString()
         bit_str.push(*TIMESTAMP_3.encode(0.133)) # 0x85
@@ -90,7 +90,7 @@ class TestParsley:
         ____ _100 0101 0011
               |-----| => _100 0100 = 0x44 = ALT_ARM_STATUS
         """
-        assert msg_sid == b'\x04\x53'
+        assert msg_sid == b'\x04T'
 
         msg_data = b'\x98\x76\x54\x32\x1F'
         res = parsley.parse(msg_sid, msg_data)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/8599d67e-1c9f-4372-b6f5-9822f2d42a2e)

Update unit test to support new message_types (100% pass) 

- I did commit two following function (deprecated): `test_radi_value(self, bit_str3)` and `test_radi_value(self, bit_str3)`

**This closed issue** #10 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/parsley/18)
<!-- Reviewable:end -->
