### PR TITLE
Added pyproject.toml to replace legacy editable install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+# pyproject.toml
+[build-system]
+requires = ["setuptools >= 64"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Exactly what the title says. Legacy `setup.py develop` installation stops working in April. Adding `pyproject.toml` to the root fixes it.
This fixes the following warning:
<img width="990" alt="image" src="https://github.com/user-attachments/assets/a8e5126a-c38e-48b1-a78b-8dada657b4b8" />
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/parsley/22)
<!-- Reviewable:end -->
