### PR TITLE
Refactor parse_logger to handle structured logger records with error …

### DIFF
--- a/parsley/parsley.py
+++ b/parsley/parsley.py
@@ -142,11 +142,11 @@ def parse_logger(buf: bytes, page_number: int) -> Union[Tuple[bytes, bytes], Non
     
     offset = 4 # start of the header
 
-    while (4096 - offset > 2 * HEADER_LEN): # at least one message
+    while (4096 - offset > HEADER_LEN): # at least one message
         sid, _, dlc = struct.unpack_from(HEADER_FMT, buf, offset)
 
-        if sid & 0xE000_0000: # SID[31:29] must be 0
-            raise ValueError("SID[31:29] must be zero")
+        if sid & 0xE000_0000:
+            break
 
         if not 0 <= dlc <= 8:
             raise ValueError(f"DLC out of range (0-8), got {dlc}")
@@ -155,7 +155,7 @@ def parse_logger(buf: bytes, page_number: int) -> Union[Tuple[bytes, bytes], Non
 
         offset += HEADER_LEN + dlc
 
-    return format_can_message(sid, data)
+        yield format_can_message(sid, data)
 
 # our three parsing functions create ints, but after the rewrite, they should return bytes
 def format_can_message(msg_sid: int, msg_data: List[int]) -> Tuple[bytes, bytes]:

--- a/parsley/parsley.py
+++ b/parsley/parsley.py
@@ -110,13 +110,64 @@ def parse_usb_debug(line: str) -> Union[Tuple[bytes, bytes], None]:
 
     return format_can_message(msg_sid, msg_data)
 
-def parse_logger(line: str) -> Union[Tuple[bytes, bytes], None]:
-    line = line.strip(' \0\r\n')
-    # see https://github.com/waterloo-rocketry/cansw_logger/blob/2075484bb64fabdfa4af48fad42a7fc376c2c347/Core/Src/can_syslog.c#L15 for format
-    msg_timestamp, msg_sid, msg_data = line[:8], line[8:16], line[16:]
-    msg_sid = int(msg_sid, 16)
-    msg_data = [int(msg_data[i:i+2], 16) for i in range(0, len(msg_data), 2)]
-    return format_can_message(msg_sid, msg_data)
+def parse_logger(buf: bytes) -> Union[Tuple[bytes, bytes], None]:
+    """
+    Parse one logger record.
+
+    Layout  (little-endian unless stated):
+        0  – 2  : ASCII 'L','O','G'
+        3       : page number (uint8)
+        4  – 12 : SID (uint32 LE) | timestamp (uint32 LE) | DLC (uint8)
+        13 – .. : up to 8 bytes CAN payload
+        -- ff-padding may follow, removed before parsing --
+
+    Returns whatever `format_can_message()` returns.
+    Raises ValueError on any structural problem.
+    """
+
+    import struct
+    LOG_MAGIC = b"LOG"          # ASCII “LOG” = 0x4c4f47
+    HEADER_FMT = "<IIB"         # SID(uint32 LE), timestamp(uint32 LE), DLC(uint8)
+    HEADER_LEN = struct.calcsize(HEADER_FMT)   # == 9
+
+    # ------------------------------------------------------------------ strip #
+    buf = buf.rstrip(b"\xff")                   # ignore trailing padding
+    if len(buf) < 4 + HEADER_LEN:               # "LOG" + page + header
+        raise ValueError("Logger message too short")
+
+    # ----------------------------------------------------------------- magic #
+    if not buf.startswith(LOG_MAGIC):
+        raise ValueError("Missing 'LOG' signature")
+
+    page_number = buf[3]
+    offset = 4                                   # we consumed 4 bytes so far
+
+    # ------------------------------------------------------------- header --- #
+    if len(buf) - offset < HEADER_LEN:
+        raise ValueError("Buffer ends inside header")
+
+    sid, timestamp, dlc = struct.unpack_from(HEADER_FMT, buf, offset)
+    offset += HEADER_LEN
+
+    if sid & 0xE000_0000:                        # SID[31:29] must be 0
+        raise ValueError("SID[31:29] must be zero")
+
+    if not 0 <= dlc <= 8:
+        raise ValueError(f"DLC out of range (0-8), got {dlc}")
+
+    # --------------------------------------------------------------- payload #
+    if len(buf) - offset < dlc:
+        raise ValueError("Payload shorter than DLC indicates")
+
+    data: List[int] = list(buf[offset: offset + dlc])
+
+    # --------------------------------------------------------------- logging #
+    print(
+        "page=%d sid=0x%08x timestamp=%d dlc=%d data=%s"
+        % (page_number, sid, timestamp, dlc, data)
+    )
+
+    return format_can_message(sid, data)
 
 # our three parsing functions create ints, but after the rewrite, they should return bytes
 def format_can_message(msg_sid: int, msg_data: List[int]) -> Tuple[bytes, bytes]:

--- a/parsley/parsley.py
+++ b/parsley/parsley.py
@@ -137,8 +137,8 @@ def parse_logger(buf: bytes, page_number: int) -> Union[Tuple[bytes, bytes], Non
     if not buf.startswith(LOG_MAGIC):
         raise ValueError("Missing 'LOG' signature")
 
-    if (buf[3] != page_number):
-        raise ValueError(f"Page number mismatch: expected {page_number}, got {buf[3]}")
+    if buf[3] != page_number % 256:
+        raise ValueError(f"Page number mismatch: expected {page_number % 256}, got {buf[3]}")
     
     offset = 4 # start of the header
 

--- a/parsley/parsley.py
+++ b/parsley/parsley.py
@@ -151,9 +151,11 @@ def parse_logger(buf: bytes, page_number: int) -> Union[Tuple[bytes, bytes], Non
         if not 0 <= dlc <= 8:
             raise ValueError(f"DLC out of range (0-8), got {dlc}")
 
+        offset += HEADER_LEN
+
         data: List[int] = list(buf[offset: offset + dlc])
 
-        offset += HEADER_LEN + dlc
+        offset += dlc
 
         yield format_can_message(sid, data)
 


### PR DESCRIPTION
This pull request includes a significant rewrite of the `parse_logger` function in `parsley/parsley.py` to improve its robustness, readability, and adherence to the expected logger record format. The new implementation introduces structured parsing with validation and error handling.

### Changes to `parse_logger` function:

* **Improved Input Handling**:
  - Changed the input type from `str` to `bytes` to align with the binary format of logger records.

* **Logger Record Parsing**:
  - Added a detailed docstring explaining the binary layout of the logger record, including the structure of the header and payload.
  - Introduced the use of the `struct` module for parsing the header (`SID`, `timestamp`, and `DLC`) in a structured and endian-aware manner.

* **Validation and Error Handling**:
  - Implemented validations for logger record structure, including checks for the "LOG" signature, header completeness, `SID` constraints, `DLC` range, and payload length. Raises `ValueError` for any structural issues.

* **Logging for Debugging**:
  - Added a `print` statement to log parsed values (`page_number`, `SID`, `timestamp`, `DLC`, and `data`) for debugging purposes.…handling

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/parsley/33)
<!-- Reviewable:end -->
