### PR TITLE
hotfix (?) to make error messages somewhat readable

### DIFF
--- a/parsley/fields.py
+++ b/parsley/fields.py
@@ -216,7 +216,7 @@ class Bitfield(Field):
             
         # For custom bitfields, just return the raw data
         if self.map_name_offset is None:
-            return data.hex()
+            return bin(int.from_bytes(data, byteorder='big', signed=False))
 
         bitfield_value = int.from_bytes(data, byteorder='big')
 

--- a/parsley/message_definitions.py
+++ b/parsley/message_definitions.py
@@ -14,7 +14,7 @@ MESSAGE_SID = Enum('msg_sid', MESSAGE_PRIO.length + MESSAGE_TYPE.length + 2 + BO
 # we parse BOARD_ID seperately from the CAN message (since we want to continue parsing even if BOARD_ID throws)
 # but BOARD_ID is still here so that Omnibus has all the fields it needs when creating messages to send
 MESSAGES = {
-    'GENERAL_BOARD_STATUS': [MESSAGE_PRIO, BOARD_TYPE_ID, BOARD_INST_ID, TIMESTAMP_2, Bitfield("general_board_status", 24, "E_NOMINAL", mt.general_board_status_offset), Numeric('board_error_bitfield', 16)],
+    'GENERAL_BOARD_STATUS': [MESSAGE_PRIO, BOARD_TYPE_ID, BOARD_INST_ID, TIMESTAMP_2, Bitfield("general_board_status", 32, "E_NOMINAL", mt.general_board_status_offset), Bitfield('board_error_bitfield', 16)],
     'RESET_CMD':            [MESSAGE_PRIO, BOARD_TYPE_ID, BOARD_INST_ID, TIMESTAMP_2, Enum('board_type_id', 8, mt.board_type_id), Enum('board_inst_id', 8, mt.board_inst_id)],
     'DEBUG_RAW':            [MESSAGE_PRIO, BOARD_TYPE_ID, BOARD_INST_ID, TIMESTAMP_2, ASCII('string', 48)],
     'CONFIG_SET':           [MESSAGE_PRIO, BOARD_TYPE_ID, BOARD_INST_ID, TIMESTAMP_2, Enum('board_type_id', 8, mt.board_type_id), Enum('board_inst_id', 8, mt.board_inst_id), Numeric('config_id', 16), Numeric('config_value', 16)],


### PR DESCRIPTION
this sure is something
<img width="947" alt="Screenshot 2025-07-09 at 10 16 21 PM" src="https://github.com/user-attachments/assets/3657aded-9527-4ae5-8935-c9d127e07d50" />
<img width="926" alt="Screenshot 2025-07-09 at 10 16 34 PM" src="https://github.com/user-attachments/assets/79cfeedd-4bad-4ff2-8b9a-165fe966031f" />
<img width="1008" alt="Screenshot 2025-07-09 at 10 16 54 PM" src="https://github.com/user-attachments/assets/c4dc13f5-0009-441e-8de2-882c6b5a8dd1" />

tested on inj sensor hub, works decently. doesn't parse board-specific errors well. not a lot we can do about that right now. whatever its fine.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/parsley/35)
<!-- Reviewable:end -->
