### PR TITLE
Fixed Bitfield tests for test_fields.py

### DIFF
--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -2,116 +2,133 @@ import pytest
 
 from parsley.fields import ASCII, Enum, Numeric, Switch, Floating, Bitfield
 
-from parsley import message_types as mt 
+from parsley import message_types as mt
+from utils import approx
+
 
 class TestASCII:
     def test_ASCII(self):
-        a = ASCII('string', 32)
-        (data, length) = a.encode('aBcD')
-        assert data == b'\x61\x42\x63\x44'
+        a = ASCII("string", 32)
+        (data, length) = a.encode("aBcD")
+        assert data == b"\x61\x42\x63\x44"
         assert length == 32
-        data = a.decode(b'\x4C\x4D\x41\x4F')
-        assert data == 'LMAO'
+        data = a.decode(b"\x4c\x4d\x41\x4f")
+        assert data == "LMAO"
 
     def test_ASCII_spaces(self):
-        a = ASCII('string', 32)
-        assert a.decode(b'\x20\x20\x57\x20') == '  W '
+        a = ASCII("string", 32)
+        assert a.decode(b"\x20\x20\x57\x20") == "  W "
 
     def test_ASCII_front_padding(self):
-        a = ASCII('string', 32)
-        assert a.decode(b'\x57') == 'W'
+        a = ASCII("string", 32)
+        assert a.decode(b"\x57") == "W"
 
     # there is an interesting behaviour when encoding partial ASCII data:
     # we want the text to be left-aligned (instead of the normal right-aligned seen everywhere else)
     def test_ASCII_partial(self):
-        a = ASCII('string', 32)
-        (data, _) = a.encode('a')
-        assert data == b'a\x00\x00\x00'
+        a = ASCII("string", 32)
+        (data, _) = a.encode("a")
+        assert data == b"a\x00\x00\x00"
 
     def test_ASCII_decode_encode(self):
-        a = ASCII('string', 32)
-        assert a.decode(a.encode('1234')[0]) == '1234'
+        a = ASCII("string", 32)
+        assert a.decode(a.encode("1234")[0]) == "1234"
 
     def test_ASCII_empty(self):
-        a = ASCII('string', 32)
-        assert a.encode('')[0] == b'\x00\x00\x00\x00'
+        a = ASCII("string", 32)
+        assert a.encode("")[0] == b"\x00\x00\x00\x00"
 
     def test_ASCII_error_not_str(self):
-        a = ASCII('string', 16)
+        a = ASCII("string", 16)
         with pytest.raises(ValueError):
-            a.encode(b'12')
+            a.encode(b"12")
         with pytest.raises(ValueError):
             a.encode(12)
 
     def test_ASCII_error_not_ASCII(self):
-        a = ASCII('string', 16)
+        a = ASCII("string", 16)
         with pytest.raises(ValueError):
-            a.encode('😎')
+            a.encode("😎")
 
     def test_ASCII_error_length(self):
-        a = ASCII('string', 16)
+        a = ASCII("string", 16)
         with pytest.raises(ValueError):
-            a.encode('xdd')
-    
+            a.encode("xdd")
+
+
 class TestEnum:
-   
+    def test_enum(self):
+        enum = Enum("enum", 8, mt.board_type_id)
+        (data, length) = enum.encode("INJ_SENSOR")
+        assert data == b"\x01"
+        assert length == 8
+        data = enum.decode(b"\x40")
+        assert data == "PAY_SENSOR"
+
+    def test_numeric_scale_imprecision(self):
+        num = Numeric("time", 24, scale=1 / 1000)
+        (data, _) = num.encode(54.321)
+        converted_data = num.decode(data)
+        assert 54.321 == approx(converted_data)
+
     def test_enum_decode_encode(self):
-        map = { 'a': 1, 'b': 10, 'c': 100 }
-        enum = Enum('enum', 8, map)
-        assert enum.decode(enum.encode('a')[0]) == 'a'
+        map = {"a": 1, "b": 10, "c": 100}
+        enum = Enum("enum", 8, map)
+        assert enum.decode(enum.encode("a")[0]) == "a"
 
     def test_enum_error_bijective(self):
-        map = { 'a': 1, 'b': 0, 'c': 1 }
+        map = {"a": 1, "b": 0, "c": 1}
         with pytest.raises(ValueError):
-            Enum('enum', 8, map)
+            Enum("enum", 8, map)
 
     def test_enum_error_init_neg(self):
-        map = { 'a': -1, 'b': 0, 'c': 1 }
+        map = {"a": -1, "b": 0, "c": 1}
         with pytest.raises(ValueError):
-            Enum('enum', 8, map)
+            Enum("enum", 8, map)
 
     def test_enum_error_length(self):
-        map = { 'max': 0x3f3f3f3f }
+        map = {"max": 0x3F3F3F3F}
         with pytest.raises(ValueError):
-            Enum('enum', 8, map)
+            Enum("enum", 8, map)
 
     def test_enum_error_contains(self):
-        map = { 'a': 1, 'b': 2, 'c': 3 }
-        enum = Enum('enum', 8, map)
+        map = {"a": 1, "b": 2, "c": 3}
+        enum = Enum("enum", 8, map)
         with pytest.raises(ValueError):
-            enum.encode('d')
+            enum.encode("d")
+
 
 class TestNumeric:
     def test_numeric(self):
-        num = Numeric('num', 8)
+        num = Numeric("num", 8)
         (data, length) = num.encode(250)
-        assert data == b'\xFA'
+        assert data == b"\xfa"
         assert length == 8
-        data = num.decode(b'\x21')
+        data = num.decode(b"\x21")
         assert data == 33
 
     def test_numeric_scale(self):
-        num = Numeric('time', 8, scale=2)
+        num = Numeric("time", 8, scale=2)
         (data, _) = num.encode(12)
-        assert data == b'\x06'
+        assert data == b"\x06"
 
-        num = Numeric('time', 8, scale=1/2)
+        num = Numeric("time", 8, scale=1 / 2)
         (data, _) = num.encode(12)
-        assert data == b'\x18'
+        assert data == b"\x18"
 
     def test_numeric_decode_encode(self):
-        num = Numeric('num', 8)
+        num = Numeric("num", 8)
         assert num.decode(num.encode(255)[0]) == 255
 
     def test_numeric_error_not_num(self):
-        num = Numeric('num', 8)
+        num = Numeric("num", 8)
         with pytest.raises(ValueError):
-            num.encode(b'12')
+            num.encode(b"12")
         with pytest.raises(ValueError):
-            num.encode('12')
+            num.encode("12")
 
     def test_numeric_error_unsigned(self):
-        num = Numeric('num', 8)
+        num = Numeric("num", 8)
         num.encode(0)
         num.encode(255)
         with pytest.raises(ValueError):
@@ -120,7 +137,7 @@ class TestNumeric:
             num.encode(256)
 
     def test_numeric_error_signed(self):
-        num = Numeric('num', 8, signed=True)
+        num = Numeric("num", 8, signed=True)
         num.encode(-128)
         num.encode(0)
         num.encode(127)
@@ -130,7 +147,7 @@ class TestNumeric:
             num.encode(128)
 
     def test_numeric_error_scale_bounds(self):
-        num = Numeric('num', 8, scale=1/4)
+        num = Numeric("num", 8, scale=1 / 4)
         num.encode(0)
         num.encode(63)
         with pytest.raises(ValueError):
@@ -138,7 +155,7 @@ class TestNumeric:
         with pytest.raises(ValueError):
             num.encode(64)
 
-        num = Numeric('num', 8, signed=True, scale=1/4)
+        num = Numeric("num", 8, signed=True, scale=1 / 4)
         num.encode(-32)
         num.encode(0)
         num.encode(31)
@@ -148,14 +165,15 @@ class TestNumeric:
             num.encode(32)
 
     def test_numeric_error_neg_scale(self):
-        num = Numeric('num', 8, scale=-1/2)
+        num = Numeric("num", 8, scale=-1 / 2)
         num.encode(-5)
         with pytest.raises(ValueError):
             num.encode(5)
-            
+
+
 class TestFloating:
     def test_floating(self):
-        fl = Floating('Num')
+        fl = Floating("Num")
         # We pick these numbers to be of the form
         # k/2^i as to avoid floating point rounding
         # issues
@@ -166,26 +184,20 @@ class TestFloating:
         assert fl.decode(fl.encode(1.3125)[0]) == 1.3125
         assert fl.decode(fl.encode(69.0)[0]) == 69.0
         assert fl.decode(fl.encode(420.0)[0]) == 420.0
-    
+
+
 class TestSwitch:
     def test_switch(self):
-        enum = {
-            'a': 0x01,
-            'b': 0x02,
-            'c': 0x03
-        }
-        map_key_enum = {
-            'a': [0, 1],
-            'b': [1, 2],
-            'c': [2, 3]
-        }
-        switch = Switch('status', 8, enum, map_key_enum)
-        (data, length) = switch.encode('a')
-        assert data == b'\x01'
+        enum = {"a": 0x01, "b": 0x02, "c": 0x03}
+        map_key_enum = {"a": [0, 1], "b": [1, 2], "c": [2, 3]}
+        switch = Switch("status", 8, enum, map_key_enum)
+        (data, length) = switch.encode("a")
+        assert data == b"\x01"
         assert length == 8
         decoded_data = switch.decode(data)
-        assert decoded_data == 'a'
+        assert decoded_data == "a"
         assert switch.get_fields(decoded_data) == [0, 1]
+
 
 class TestBitfieldLogs:
     @pytest.fixture(autouse=True)
@@ -194,32 +206,37 @@ class TestBitfieldLogs:
             name="general_board_status",
             length=16,
             default="E_NOMINAL",
-            map_name_offset=mt.general_board_status_offset
+            map_name_offset=mt.general_board_status_offset,
         )
 
-    @pytest.mark.parametrize("bytes,expected", [
-        (b"\x00\x00", "E_NOMINAL"),
-        (b"\x00\x01", "E_5V_OVER_CURRENT"),
-        (b"\x00\x02", "E_5V_OVER_VOLTAGE"),
-        (b"\x00\x04", "E_5V_UNDER_VOLTAGE"),
-        (b"\x00\x08", "E_12V_OVER_CURRENT"),
-        (b"\x00\x10", "E_12V_OVER_VOLTAGE"),
-        (b"\x00\x20", "E_12V_UNDER_VOLTAGE"),
-        (b"\x00\x40", "E_BATT_OVER_CURRENT"),
-        (b"\x00\x80", "E_BATT_OVER_VOLTAGE"),
-        (b"\x01\x00", "E_BATT_UNDER_VOLTAGE"),
-        (b"\x02\x00", "E_MOTOR_OVER_CURRENT"),
-        (b"\x04\x00", "E_IO_ERROR"),
-        (b"\x08\x00", "E_FS_ERROR"),
-        (b"\x10\x00", "E_WATCHDOG_TIMEOUT"),
-
-    ])
+    @pytest.mark.parametrize(
+        "bytes,expected",
+        [
+            (b"\x00\x00", "E_NOMINAL"),
+            (b"\x00\x01", "E_5V_OVER_CURRENT"),
+            (b"\x00\x02", "E_5V_OVER_VOLTAGE"),
+            (b"\x00\x04", "E_5V_UNDER_VOLTAGE"),
+            (b"\x00\x08", "E_12V_OVER_CURRENT"),
+            (b"\x00\x10", "E_12V_OVER_VOLTAGE"),
+            (b"\x00\x20", "E_12V_UNDER_VOLTAGE"),
+            (b"\x00\x40", "E_BATT_OVER_CURRENT"),
+            (b"\x00\x80", "E_BATT_OVER_VOLTAGE"),
+            (b"\x01\x00", "E_BATT_UNDER_VOLTAGE"),
+            (b"\x02\x00", "E_MOTOR_OVER_CURRENT"),
+            (b"\x04\x00", "E_IO_ERROR"),
+            (b"\x08\x00", "E_FS_ERROR"),
+            (b"\x10\x00", "E_WATCHDOG_TIMEOUT"),
+        ],
+    )
     def test_decode_various_logs(self, bitfield, bytes, expected):
         assert bitfield.decode(bytes) == expected
 
-    @pytest.mark.parametrize("bytes,expected", [
-        (b"\x00\x03", "E_5V_OVER_CURRENT|E_5V_OVER_VOLTAGE"),
-        (b"\x00\x05", "E_5V_OVER_CURRENT|E_5V_UNDER_VOLTAGE"),
-    ])  
+    @pytest.mark.parametrize(
+        "bytes,expected",
+        [
+            (b"\x00\x03", "E_5V_OVER_CURRENT|E_5V_OVER_VOLTAGE"),
+            (b"\x00\x05", "E_5V_OVER_CURRENT|E_5V_UNDER_VOLTAGE"),
+        ],
+    )
     def test_decode_from_bytes(self, bitfield, bytes, expected):
         assert bitfield.decode(bytes) == expected


### PR DESCRIPTION
Fixed imports
Replaced large, unrelated hex strings with direct 2-byte binary values representing specific bit combinations.
Fixed individual bit mapping tests for each flag.
Fixed/Added combined bit flag tests.

<img width="740" height="440" alt="image" src="https://github.com/user-attachments/assets/9077b9e4-900e-489d-a533-80b40d3713c3" />
<img width="1623" height="267" alt="image" src="https://github.com/user-attachments/assets/f616e48d-43a6-4345-b2c2-0fd61e8f7baf" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/parsley/46)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **API Updates**
  * Bitfield initialization signature updated: `width` parameter removed from constructor.
  * Enum field mappings refined with updated symbolic identifiers.

* **Tests**
  * Enhanced test coverage for numeric precision validation.
  * Expanded bitfield decoding verification across multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->