### PR TITLE
Fixing can metadata

### DIFF
--- a/tests/test_can_metadata.py
+++ b/tests/test_can_metadata.py
@@ -34,3 +34,15 @@ class TestCANMetadata:
         assert res['imu_id'] == 'IMU_PROC_LSM6DSO32'
         assert res['linear_accel'] == 1234
         assert res['angular_velocity'] == 5678
+        
+    def test_timestamp2_second(self):
+        msg_data = BitString()
+        msg_data.push(*TIMESTAMP_2.encode(1.234))
+        msg_data.push(*Enum('actuator', 8, mt.actuator_id).encode('ACTUATOR_5V_RAIL_PAYLOAD'))
+        msg_data.push(*Enum('cmd_state', 8, mt.actuator_state).encode('ACT_STATE_ON'))
+
+        res = parsley.parse_fields(msg_data, CAN_MESSAGE.get_fields('ACTUATOR_CMD')[3:]) # skip first 3 fields (MESSAGE_PRIO, BOARD_TYPE_ID, BOARD_INST_ID)
+        assert res['time'] == tu.approx(1.234)
+        assert res['actuator'] == 'ACTUATOR_5V_RAIL_PAYLOAD'
+        assert res['cmd_state'] == 'ACT_STATE_ON'
+       

--- a/tests/test_can_metadata.py
+++ b/tests/test_can_metadata.py
@@ -35,7 +35,7 @@ class TestCANMetadata:
         assert res['linear_accel'] == 1234
         assert res['angular_velocity'] == 5678
         
-    def test_timestamp2_second(self):
+    def test_timestamp2_message_again(self):
         msg_data = BitString()
         msg_data.push(*TIMESTAMP_2.encode(1.234))
         msg_data.push(*Enum('actuator', 8, mt.actuator_id).encode('ACTUATOR_5V_RAIL_PAYLOAD'))

--- a/tests/test_can_metadata.py
+++ b/tests/test_can_metadata.py
@@ -37,12 +37,12 @@ class TestCANMetadata:
         
     def test_timestamp2_message_again(self):
         msg_data = BitString()
-        msg_data.push(*TIMESTAMP_2.encode(1.234))
+        msg_data.push(*TIMESTAMP_2.encode(32.69))
         msg_data.push(*Enum('actuator', 8, mt.actuator_id).encode('ACTUATOR_5V_RAIL_PAYLOAD'))
         msg_data.push(*Enum('cmd_state', 8, mt.actuator_state).encode('ACT_STATE_ON'))
 
         res = parsley.parse_fields(msg_data, CAN_MESSAGE.get_fields('ACTUATOR_CMD')[3:]) # skip first 3 fields (MESSAGE_PRIO, BOARD_TYPE_ID, BOARD_INST_ID)
-        assert res['time'] == tu.approx(1.234)
+        assert res['time'] == tu.approx(32.69)
         assert res['actuator'] == 'ACTUATOR_5V_RAIL_PAYLOAD'
         assert res['cmd_state'] == 'ACT_STATE_ON'
        

--- a/tests/test_can_metadata.py
+++ b/tests/test_can_metadata.py
@@ -34,15 +34,3 @@ class TestCANMetadata:
         assert res['imu_id'] == 'IMU_PROC_LSM6DSO32'
         assert res['linear_accel'] == 1234
         assert res['angular_velocity'] == 5678
-        
-    def test_timestamp2_message_again(self):
-        msg_data = BitString()
-        msg_data.push(*TIMESTAMP_2.encode(32.69))
-        msg_data.push(*Enum('actuator', 8, mt.actuator_id).encode('ACTUATOR_5V_RAIL_PAYLOAD'))
-        msg_data.push(*Enum('cmd_state', 8, mt.actuator_state).encode('ACT_STATE_ON'))
-
-        res = parsley.parse_fields(msg_data, CAN_MESSAGE.get_fields('ACTUATOR_CMD')[3:]) # skip first 3 fields (MESSAGE_PRIO, BOARD_TYPE_ID, BOARD_INST_ID)
-        assert res['time'] == tu.approx(32.69)
-        assert res['actuator'] == 'ACTUATOR_5V_RAIL_PAYLOAD'
-        assert res['cmd_state'] == 'ACT_STATE_ON'
-       


### PR DESCRIPTION
Edited the test_can_metadata.py test file. Removed the old depricated timestamp3, leaving just timestamp2 tests. 

<img width="598" height="97" alt="Screenshot 2025-10-30 at 10 57 40 PM" src="https://github.com/user-attachments/assets/3bebded0-68c4-4b68-9625-dd65146c0985" />

https://github.com/waterloo-rocketry/2025-software-issues/issues/33?issue=waterloo-rocketry%7C2025-software-issues%7C74

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/parsley/48)
<!-- Reviewable:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test suite imports and expanded test coverage for CAN sensor metadata validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->