### PR TITLE
Make Jason codeowner only on CAN message definition files and update version number

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
-* @JasonBrave
+src/parsley/message_types.py @JasonBrave
+src/parsley/message_definitions.py @JasonBrave

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ module-name = "parsley"
 
 [project]
 name = "parsley"
-version = "2025.4"
+version = "2026.2"
 description = "Library to transcode CAN messages and human-readable text"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/parsley/52)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Narrowed a global code ownership entry to specific code areas (reassigning ownership scope).
  * Bumped project version from 2025.4 to 2026.2.

---

*Note: This release contains internal administrative updates only; there are no user-facing changes.*

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->