### PR TITLE
Fixed broken tests from previous pr

### DIFF
--- a/src/parsley/parsley.py
+++ b/src/parsley/parsley.py
@@ -48,7 +48,7 @@ def parse(msg_sid: bytes, msg_data: bytes) -> dict:
         # if BOARD_ID threw an error, we want to try and parse the rest of the CAN message
         fields = CAN_MESSAGE.get_fields(res['msg_type'])[3:]
         res['data'] = parse_fields(BitString(msg_data), fields)
-    except (ValueError, IndexError) as error:
+    except (ValueError, IndexError, KeyError) as error:
         res.update({
             # convert the 6-bit msg_type into its canlib 12-bit form
             'msg_type': pu.hexify(encoded_msg_type, is_msg_type=True),

--- a/tests/test_parsley.py
+++ b/tests/test_parsley.py
@@ -78,9 +78,9 @@ class TestParsley:
         msg_sid = utilities.create_msg_sid_from_strings('MEDIUM', 'SENSOR_ANALOG', '0', 'PAY_SENSOR', 'ANY')
         
         """
-        MEDIUM = 0x2, SENSOR_ANALOG = 0x014, PAY_SENSOR = 0x40, ANY = 0x00
+        MEDIUM = 0x2, SENSOR_ANALOG = 0x013, PAY_SENSOR = 0x40, ANY = 0x00
         """
-        assert msg_sid == b'\x10\x50\x40\x00'
+        assert msg_sid == b'\x10\x4c\x40\x00'
 
         bit_str = BitString()
         bit_str.push(*TIMESTAMP_2.encode(12.345)) 


### PR DESCRIPTION
After [link](https://github.com/waterloo-rocketry/parsley/pull/44) pr some of the test cases broke. Fixed them.

Before:
<img width="1360" height="91" alt="Screenshot 2025-12-16 at 2 24 46 PM 1" src="https://github.com/user-attachments/assets/28616f6c-00a4-4a2d-abc5-ec96a37b3709" />

After:

<img width="1230" height="135" alt="Screenshot 2025-12-16 at 3 31 23 PM" src="https://github.com/user-attachments/assets/08fdb9a7-bf03-4e86-b852-327111a3dbdd" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/parsley/53)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved message parsing error handling to capture and gracefully handle additional error types with enhanced diagnostic information for better troubleshooting.

* **Tests**
  * Added comprehensive tests for stream status, data, and retry message validation.
  * Updated sensor analog encoding reference values to reflect current specifications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->