### PR TITLE
Bump version number to 2026.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ module-name = "parsley"
 
 [project]
 name = "parsley"
-version = "2026.2"
+version = "2026.3"
 description = "Library to transcode CAN messages and human-readable text"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -176,7 +176,7 @@ wheels = [
 
 [[package]]
 name = "parsley"
-version = "2026.2"
+version = "2026.3"
 source = { editable = "." }
 dependencies = [
     { name = "crc8" },


### PR DESCRIPTION
Since 2026.2 just got released, bump latest development main version to 2026.3

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/parsley/59)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 2026.3

<!-- end of auto-generated comment: release notes by coderabbit.ai -->