### PR TITLE
Add to_flat_dict method for ParsleyError and ParsleyObject classes. A…

### DIFF
--- a/src/parsley/parsley_message.py
+++ b/src/parsley/parsley_message.py
@@ -25,9 +25,7 @@ class ParsleyError():
         return asdict(self)[key]
     
     def to_flat_dict(self) -> dict[str, Any]:
-        dumped = asdict(self)
-        error_data = {"error": dumped.pop("error"), "msg_data": dumped.pop("msg_data")}
-        return {**dumped, **error_data}
+        return asdict(self)
     
 class ParsleyObject(BaseModel, Generic[T]):
     """

--- a/src/parsley/parsley_message.py
+++ b/src/parsley/parsley_message.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, asdict
-from typing import Generic, TypeVar
+from typing import Generic, TypeVar, Any
 from pydantic import BaseModel, field_validator
 import parsley.message_types as mt
 
@@ -23,6 +23,11 @@ class ParsleyError():
 
     def __getitem__(self, key: str):
         return asdict(self)[key]
+    
+    def to_flat_dict(self) -> dict[str, Any]:
+        dumped = asdict(self)
+        error_data = {"error": dumped.pop("error"), "msg_data": dumped.pop("msg_data")}
+        return {**dumped, **error_data}
     
 class ParsleyObject(BaseModel, Generic[T]):
     """
@@ -56,3 +61,12 @@ class ParsleyObject(BaseModel, Generic[T]):
     
     def __getitem__(self, key: str):        
         return self.model_dump()[key]
+    
+    def to_flat_dict(self) -> dict[str, Any]:
+    
+        dumped = self.model_dump()
+        
+        nested_data = dumped.pop("data", {})
+        
+        return {**dumped, **nested_data}
+

--- a/tests/test_parsley_message.py
+++ b/tests/test_parsley_message.py
@@ -99,3 +99,25 @@ def test_parsley_object_to_flat_dict():
     assert 'data' not in flat
     assert flat['mag_x'] == 100
     assert len(flat) == 8
+
+def test_parsley_error_to_flat_dict():
+    err = ParsleyError(
+        board_type_id='GPS',
+        board_inst_id='ROCKET',
+        msg_type='GPS_ALTITUDE',
+        msg_metadata=0x42,
+        msg_data='0xFFEEDDCC',
+        error='ChecksumMismatch: GPS packet corrupted'
+    )
+    flat_err = err.to_flat_dict()
+    assert flat_err['board_type_id'] == 'GPS'
+    assert flat_err['board_inst_id'] == 'ROCKET'
+    assert flat_err['msg_type'] == 'GPS_ALTITUDE'
+    
+    assert 'error' in flat_err
+    assert 'msg_data' in flat_err
+    
+    assert isinstance(flat_err, dict)
+    assert len(flat_err) == 6
+
+    

--- a/tests/test_parsley_message.py
+++ b/tests/test_parsley_message.py
@@ -76,3 +76,26 @@ def test_parsley_object_invalid_type_raises():
             msg_metadata=0,
             data={}
         )
+
+def test_parsley_object_to_flat_dict():
+    sensor_data = {
+        'time': 40.423, 
+        'mag_x': 100, 
+        'mag_y': 200
+    }
+
+    obj = ParsleyObject(
+        board_type_id='PROCESSOR',
+        board_inst_id='GENERIC',
+        msg_prio='LOW',
+        msg_type='RESET_CMD',  
+        msg_metadata=10,
+        data=sensor_data
+    )
+
+    flat = obj.to_flat_dict()
+
+    assert flat['board_type_id'] == 'PROCESSOR'
+    assert 'data' not in flat
+    assert flat['mag_x'] == 100
+    assert len(flat) == 8


### PR DESCRIPTION
Add series flattening to Parsley to parsley_message.py. Also added simple unit test (all passing)

**This was done to complete 1/2 of Issue #51 on 2025_Software_Issues:**
- Series flattening SHOULD be implemented into Parsley (dependency on https://github.com/waterloo-rocketry/2025-software-issues/issues/35 )

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/parsley/61)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ability to produce flattened representations of nested message objects for simpler downstream use.

* **Tests**
  * Added tests validating flattened representations, key preservation, and expected field presence/counts to improve reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->