### PR TITLE
Add pyright strict type checking annotations

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pytest
 crc8
+deprecated

--- a/src/parsley/__init__.py
+++ b/src/parsley/__init__.py
@@ -1,3 +1,4 @@
+# pyright: strict
 from .bitstring import BitString
 from . import fields
 from . import message_definitions
@@ -12,14 +13,14 @@ from .parse_to_object import (
 )
 from .parsley import (
     parse_fields, 
-    parse, 
+    parse,  # pyright: ignore[reportUnknownVariableType]
     parse_bitstring,
     parse_live_telemetry,
     parse_usb_debug,
     parse_logger,
-    format_line,
-    encode_data,
-    calculate_msg_bit_len
+    format_line,  # pyright: ignore[reportUnknownVariableType]
+    encode_data,  # pyright: ignore[reportUnknownVariableType]
+    calculate_msg_bit_len  # pyright: ignore[reportUnknownVariableType]
 )
 
 __all__ = [

--- a/src/parsley/bitstring.py
+++ b/src/parsley/bitstring.py
@@ -1,13 +1,14 @@
+# pyright: strict
 class BitString:
     """
     Stores the message data bits that we have yet to parse and lets us read arbitrary-length
     bits from the front. We need to operate at the bit level since some fields are
     non-byte-aligned (eg. DEBUG_MSG's 4-bit DEBUG_LEVEL and DEBUG_MSG's 12-bit LINE_NUM)
     """
-    def __init__(self, data=b'', data_bit_length=0):
-        self.length = data_bit_length or len(data) * 8 # length in bits
+    def __init__(self, data: bytes = b'', data_bit_length: int = 0) -> None:
+        self.length: int = data_bit_length or len(data) * 8 # length in bits
         # store the data as an int which is unbounded and lets us do bitwise manipulations
-        self.data = int.from_bytes(data, byteorder='big')
+        self.data: int = int.from_bytes(data, byteorder='big')
 
     def pop(self, field_length: int, variable_length: bool = False) -> bytes:
         """
@@ -27,7 +28,7 @@ class BitString:
         self.data = self.data & ((1 << self.length) - 1) # and then mask them out
         return res.to_bytes((field_length + 7) // 8, byteorder='big') # and convert to a bytes object
 
-    def push(self, value: bytes, field_length: int):
+    def push(self, value: bytes, field_length: int) -> None:
         """
         Appends the next field_length least significant bits of data from value (to the back).
 
@@ -36,14 +37,14 @@ class BitString:
         will append only 110000
         """
         self.length += field_length
-        value = int.from_bytes(value, byteorder='big') # convert to int to do bitwise maniuplations
-        value = value & ((1 << field_length) - 1) # extract the field_length least significant bits
-        self.data = (self.data << field_length) | value # and then append value to the back of data
+        int_value = int.from_bytes(value, byteorder='big') # convert to int to do bitwise maniuplations
+        int_value = int_value & ((1 << field_length) - 1) # extract the field_length least significant bits
+        self.data = (self.data << field_length) | int_value # and then append value to the back of data
 
-    def push_front(self, value: bytes, field_length: int):
+    def push_front(self, value: bytes, field_length: int) -> None:
         """
         Prepends the next field_length least significant bits of data from value (to the front).
         """
-        value = int.from_bytes(value, byteorder='big')
-        self.data = (value << self.length) | self.data # prepend value to the front of data
+        int_value = int.from_bytes(value, byteorder='big')
+        self.data = (int_value << self.length) | self.data # prepend value to the front of data
         self.length += field_length

--- a/src/parsley/fields.py
+++ b/src/parsley/fields.py
@@ -1,7 +1,9 @@
-from typing import Any, Literal, Tuple, Union, Optional
+# pyright: strict
+from typing import Any, Literal
+from collections.abc import KeysView
 import struct
 
-Number = Union[int, float]
+Number = int | float
 
 class Field:
     """
@@ -9,7 +11,7 @@ class Field:
 
     Note: data is assumed to be LSB-aligned to match the implementation of BitString.
     """
-    def __init__(self, name: str, length: int, unit=""):
+    def __init__(self, name: str, length: int, unit: str = "") -> None:
         self.name = name
         self.length = length # length in bits
         self.unit = unit # optional unit description
@@ -22,7 +24,7 @@ class Field:
         """
         raise NotImplementedError
 
-    def encode(self, value: Any) -> Tuple[bytes, int]:
+    def encode(self, value: Any) -> tuple[bytes, int]:
         """
         Converts value to `self.length` bits of data and returns a tuple of (encoded_value, self.length)
         or raises a ValueError with an appropiate message if this is not possible.
@@ -49,8 +51,8 @@ class ASCII(Field):
     def decode(self, data: bytes) -> str:
         return data.replace(b'\x00', b'').decode('ascii') # remove null bytes to return original data
 
-    def encode(self, value: str) -> Tuple[bytes, int]:
-        if type(value) != str:
+    def encode(self, value: Any) -> tuple[bytes, int]:
+        if not isinstance(value, str):
             raise ValueError(f'{value} is not a string')
         if not value.isascii():
             raise ValueError(f'{value} contains non-ascii character(s)')
@@ -69,11 +71,11 @@ class Enum(Field):
     dictionary: {'GENERAL_CMD': 0x060, 'RESET_CMD': 0x160}
     b'\x01\x60' <=> 'RESET_CMD'
     """
-    def __init__(self, name: str, length: int, map_key_val: dict):
+    def __init__(self, name: str, length: int, map_key_val: dict[str, int]) -> None:
         super().__init__(name, length)
 
-        self.map_key_val = map_key_val
-        self.map_val_key = {v: k for k, v in self.map_key_val.items()}
+        self.map_key_val: dict[str, int] = map_key_val
+        self.map_val_key: dict[int, str] = {v: k for k, v in self.map_key_val.items()}
 
         # ensure map is bijective
         value_size = len(self.map_key_val.values())
@@ -88,21 +90,21 @@ class Enum(Field):
             if v >= 1 << self.length:
                 raise ValueError(f'Mapping value {v} for key {k} is too large to fit in {self.length} bits')
 
-    def decode(self, data: bytes):
+    def decode(self, data: bytes) -> str:
         value = int.from_bytes(data, byteorder='big', signed=False)
         if value not in self.map_val_key:
             raise ValueError(f'Value "{value}" not found in map "{self.name}"')
 
         return self.map_val_key[value]
 
-    def encode(self, value) -> Tuple[bytes, int]:
+    def encode(self, value: str) -> tuple[bytes, int]:
         if value not in self.map_key_val:
             raise ValueError(f'Key "{value}" not found in map "{self.name}"')
 
         encoded_data = self.map_key_val[value].to_bytes((self.length + 7) // 8, byteorder='big')
         return (encoded_data, self.length)
 
-    def get_keys(self):
+    def get_keys(self) -> KeysView[str]:
         return self.map_key_val.keys()
 
 class Numeric(Field):
@@ -113,7 +115,7 @@ class Numeric(Field):
     For example:
     b'\xFC' <=> -4 (two's complement)
     """
-    def __init__(self, name: str, length: int, scale: float=1, signed=False, big_endian=True, unit=""):
+    def __init__(self, name: str, length: int, scale: float=1, signed: bool = False, big_endian: bool = True, unit: str = "") -> None:
         super().__init__(name, length, unit)
         self.scale = scale
         self.signed = signed
@@ -123,24 +125,24 @@ class Numeric(Field):
         value = int.from_bytes(data, byteorder=self.endian, signed = self.signed)
         return value * self.scale
 
-    def encode(self, value: Number) -> Tuple[bytes, int]:
-        if not isinstance(value, Number):
+    def encode(self, value: Any) -> tuple[bytes, int]:
+        if not isinstance(value, (int, float)):
             raise ValueError(f'Value "{value}" is not a valid number')
 
-        value = int(value // self.scale)
-        hex_value = hex(value)
+        int_value = int(value // self.scale)
+        hex_value = hex(int_value)
         if not self.signed:
-            if value >= 1 << self.length:
-                raise ValueError(f'Value "{value}" ({hex_value}) is too large for {self.length} unsigned bits')
-            if value < 0:
-                raise ValueError(f'Cannot encode negative value "{value}" in an unsigned field')
+            if int_value >= 1 << self.length:
+                raise ValueError(f'Value "{int_value}" ({hex_value}) is too large for {self.length} unsigned bits')
+            if int_value < 0:
+                raise ValueError(f'Cannot encode negative value "{int_value}" in an unsigned field')
         else:
-            if value >= 1 << (self.length - 1):
-                raise ValueError(f'Value "{value}" ({hex_value}) is too large for {self.length} signed bits')
-            if value < -1 << (self.length - 1):
-                raise ValueError(f'Value "{value}" ({hex_value}) is too small for {self.length} signed bits')
+            if int_value >= 1 << (self.length - 1):
+                raise ValueError(f'Value "{int_value}" ({hex_value}) is too large for {self.length} signed bits')
+            if int_value < -1 << (self.length - 1):
+                raise ValueError(f'Value "{int_value}" ({hex_value}) is too small for {self.length} signed bits')
 
-        encoded_data = value.to_bytes((self.length + 7) // 8, byteorder=self.endian, signed=self.signed)
+        encoded_data = int_value.to_bytes((self.length + 7) // 8, byteorder=self.endian, signed=self.signed)
         return (encoded_data, self.length)
 
 class Floating(Field):
@@ -155,7 +157,7 @@ class Floating(Field):
     (Note, byte order may be reversed depending on endianess)
 
     """
-    def __init__(self, name: str, big_endian=True, unit=""):
+    def __init__(self, name: str, big_endian: bool = True, unit: str = "") -> None:
         super().__init__(name, 32, unit)
         self.endian = 'big' if big_endian else 'little'
 
@@ -165,16 +167,16 @@ class Floating(Field):
         else:
             return struct.unpack('<f', data)[0]
 
-    def encode(self, value: Number) -> Tuple[bytes, int]:
-        if not isinstance(value, Number):
+    def encode(self, value: Any) -> tuple[bytes, int]:
+        if not isinstance(value, (int, float)):
             raise ValueError(f'Value "{value}" is not a valid float')
 
-        value = float(value)
+        float_value = float(value)
 
         if self.endian == 'big':
-            encoded_data = struct.pack('>f', value)
+            encoded_data = struct.pack('>f', float_value)
         else:
-            encoded_data = struct.pack('<f', value)
+            encoded_data = struct.pack('<f', float_value)
 
         return (encoded_data, self.length)
 
@@ -186,14 +188,14 @@ class Switch(Enum):
     binary data <=> string (message type) and then
     string -> list of Fields (the specific fields that are defined in the message type)
     """
-    def __init__(self, name: str, length: int, map_key_val: dict, map_key_enum: dict):
+    def __init__(self, name: str, length: int, map_key_val: dict[str, int], map_key_enum: dict[str, list[Field]]) -> None:
         super().__init__(name, length, map_key_val)
-        self.map_key_enum = map_key_enum
+        self.map_key_enum: dict[str, list[Field]] = map_key_enum
 
-    def get_fields(self, key):
+    def get_fields(self, key: str) -> list[Field]:
         return self.map_key_enum[key]
 
-    def get_keys(self):
+    def get_keys(self) -> KeysView[str]:
         return self.map_key_val.keys()
 
 class Bitfield(Field):
@@ -205,10 +207,10 @@ class Bitfield(Field):
     dictionary: {'E_NOMINAL': 0, 'E_5V_OVER_CURRENT': 1, 'E_5V_OVER_VOLTAGE': 2}
     b'\x01\x60' <=> 'E_5V_OVER_CURRENT|E_5V_OVER_VOLTAGE'
     """
-    def __init__(self, name: str, length: int, default: str="DEFAULT_STRING", map_name_offset: Optional[dict]=None, unit=""):
+    def __init__(self, name: str, length: int, default: str="DEFAULT_STRING", map_name_offset: dict[str, int] | None = None, unit: str = "") -> None:
         super().__init__(name, length, unit)
         self.default = default
-        self.map_name_offset = map_name_offset
+        self.map_name_offset: dict[str, int] | None = map_name_offset
 
     def decode(self, data: bytes) -> str:
         if isinstance(data, str):
@@ -227,7 +229,7 @@ class Bitfield(Field):
 
         return f"{'|'.join(status)}"
 
-    def encode(self, value: Any) -> Tuple[bytes, int]:
+    def encode(self, value: Any) -> tuple[bytes, int]:
         if not isinstance(value, str):
             raise ValueError(f'Value "{value}" is not a valid bitfield string')
 

--- a/src/parsley/message_definitions.py
+++ b/src/parsley/message_definitions.py
@@ -1,4 +1,5 @@
-from parsley.fields import ASCII, Enum, Numeric, Switch, Floating, Bitfield
+# pyright: strict
+from parsley.fields import ASCII, Enum, Field, Numeric, Switch, Bitfield
 
 import parsley.message_types as mt
 
@@ -14,7 +15,7 @@ MESSAGE_SID = Enum('msg_sid', MESSAGE_PRIO.length + MESSAGE_TYPE.length + BOARD_
 
 # we parse BOARD_ID seperately from the CAN message (since we want to continue parsing even if BOARD_ID throws)
 # but BOARD_ID is still here so that Omnibus has all the fields it needs when creating messages to send
-MESSAGES = {
+MESSAGES: dict[str, list[Field]] = {
     'GENERAL_BOARD_STATUS': [MESSAGE_PRIO, BOARD_TYPE_ID, BOARD_INST_ID, MESSAGE_METADATA, TIMESTAMP_2, Bitfield("general_board_status", 32, "E_NOMINAL", mt.general_board_status_offset), Bitfield('board_error_bitfield', 16, "E_NOMINAL", mt.board_specific_status_offset)],
     'RESET_CMD':            [MESSAGE_PRIO, BOARD_TYPE_ID, BOARD_INST_ID, MESSAGE_METADATA, TIMESTAMP_2, Enum('board_type_id', 8, mt.board_type_id), Enum('board_inst_id', 8, mt.board_inst_id)],
     'DEBUG_RAW':            [MESSAGE_PRIO, BOARD_TYPE_ID, BOARD_INST_ID, MESSAGE_METADATA, TIMESTAMP_2, ASCII('string', 48)],

--- a/src/parsley/message_types.py
+++ b/src/parsley/message_types.py
@@ -1,3 +1,4 @@
+# pyright: strict
 # Auto generated file, do not edit directly
 
 msg_prio = {

--- a/src/parsley/parse_to_object.py
+++ b/src/parsley/parse_to_object.py
@@ -1,15 +1,17 @@
+# pyright: strict
 '''
 Contains the new static class implementation of Parsley.py
 '''
 from typing import Any
+from collections.abc import Generator
 from parsley.parsley_message import ParsleyObject, ParsleyError
 from parsley.bitstring import BitString
 from parsley.message_definitions import CAN_MESSAGE, MESSAGE_PRIO, MESSAGE_TYPE, BOARD_TYPE_ID, BOARD_INST_ID, MESSAGE_METADATA, MESSAGE_SID
 import parsley.parse_utils as pu
-from parsley.fields import Field, Switch, Bitfield
+from parsley.fields import Field, Switch
 from abc import ABC, abstractmethod
 import struct
-import crc8
+import crc8  # pyright: ignore[reportMissingTypeStubs]
 import parsley.message_types as mt
 
 #Used for formatting lines
@@ -19,16 +21,16 @@ BOARD_TYPE_ID_LEN = max([len(board_type_id) for board_type_id in mt.board_type_i
 BOARD_INST_ID_LEN = max([len(board_inst_id) for board_inst_id in mt.board_inst_id])
 
 class _ParsleyParseInternal:
-    def __init__(self):
+    def __init__(self) -> None:
         raise NotImplementedError("This class is static only do not instantiate it")
 
     @staticmethod
-    def format_line(parsed_data: dict) -> str:
-        msg_prio = parsed_data['msg_prio']
-        msg_type = parsed_data['msg_type']
-        board_type_id = parsed_data['board_type_id']
-        board_inst_id = parsed_data['board_inst_id']
-        data = parsed_data['data']
+    def format_line(parsed_data: dict[str, Any]) -> str:
+        msg_prio: str = parsed_data['msg_prio']
+        msg_type: str = parsed_data['msg_type']
+        board_type_id: str = parsed_data['board_type_id']
+        board_inst_id: str = parsed_data['board_inst_id']
+        data: dict[str, Any] = parsed_data['data']
         res = f'[ {msg_prio:<{MSG_PRIO_LEN}} {msg_type:<{MSG_TYPE_LEN}} {board_type_id:<{BOARD_TYPE_ID_LEN}} {board_inst_id:<{BOARD_INST_ID_LEN}} ]'
         for k, v in data.items():
             formatted_value = f"{v:.3f}" if isinstance(v, float) else v
@@ -36,19 +38,19 @@ class _ParsleyParseInternal:
         return res
 
     @staticmethod
-    def calculate_msg_bit_len(can_message):
-        bit_len = 0
+    def calculate_msg_bit_len(can_message: list[Field]) -> int:
+        bit_len: int = 0
         for field in can_message:
             bit_len += field.length
         return bit_len
 
     @staticmethod
-    def encode_data(parsed_data: dict) -> tuple[int, list[int]]:
-        msg_prio = parsed_data['msg_prio']
-        msg_type = parsed_data['msg_type']
-        board_type_id = parsed_data['board_type_id']
-        board_inst_id = parsed_data['board_inst_id']
-        msg_metadata = parsed_data['msg_metadata']
+    def encode_data(parsed_data: dict[str, Any]) -> tuple[int, list[int]]:
+        msg_prio: str = parsed_data['msg_prio']
+        msg_type: str = parsed_data['msg_type']
+        board_type_id: str = parsed_data['board_type_id']
+        board_inst_id: str = parsed_data['board_inst_id']
+        msg_metadata: Any = parsed_data['msg_metadata']
 
         bit_str = BitString()
         bit_str.push(*MESSAGE_PRIO.encode(msg_prio))
@@ -108,22 +110,24 @@ class _ParsleyParseInternal:
 
     @staticmethod
     def parse_msg_metadata(encoded_msg_metadata: bytes) -> int:
-        return MESSAGE_METADATA.decode(encoded_msg_metadata) #no try-catch since we want to error out if metadata is malformed
+        result: Any = MESSAGE_METADATA.decode(encoded_msg_metadata)
+        return int(result)
     
     @staticmethod
-    def parse_to_object(msg_sid: bytes, msg_data: bytes) -> ParsleyObject | ParsleyError:
+    def parse_to_object(msg_sid: bytes | int, msg_data: bytes | list[int]) -> ParsleyObject[dict[str, Any]] | ParsleyError:
         """
         Extracts the message_type and board_id from msg_sid to construct a Parsley Object along with message_data.
         Upon reading poorly formatted data, the error is caught and returned in a ParsleyError object.
         """
-        # Allow callers to pass integer SID
+        # Normalize inputs to bytes
         if isinstance(msg_sid, int):
-            sid_bytes, data_bytes = _ParsleyParseInternal.format_can_message(msg_sid,list(msg_data))
-            msg_sid = sid_bytes
-            msg_data = data_bytes
+            msg_sid_bytes, msg_data_bytes = _ParsleyParseInternal.format_can_message(msg_sid, list(msg_data))
+        else:
+            msg_sid_bytes = msg_sid
+            msg_data_bytes = msg_data if isinstance(msg_data, bytes) else bytes(msg_data)
         
         # begin parsing
-        bit_str_msg_sid = BitString(msg_sid, MESSAGE_SID.length)
+        bit_str_msg_sid = BitString(msg_sid_bytes, MESSAGE_SID.length)
         encoded_msg_prio = bit_str_msg_sid.pop(MESSAGE_PRIO.length)
         encoded_msg_type = bit_str_msg_sid.pop(MESSAGE_TYPE.length)
         encoded_board_type_id = bit_str_msg_sid.pop(BOARD_TYPE_ID.length)
@@ -134,17 +138,13 @@ class _ParsleyParseInternal:
         board_inst_id = _ParsleyParseInternal.parse_board_inst_id(encoded_board_inst_id)
         msg_metadata = _ParsleyParseInternal.parse_msg_metadata(encoded_msg_metadata)
 
-        msg_prio = None
-        msg_type = None
-        data: dict[str, Any] = {}
-
         try:
-            msg_prio = MESSAGE_PRIO.decode(encoded_msg_prio)
-            msg_type = MESSAGE_TYPE.decode(encoded_msg_type)
+            msg_prio: str = MESSAGE_PRIO.decode(encoded_msg_prio)
+            msg_type: str = MESSAGE_TYPE.decode(encoded_msg_type)
             # we splice the first element since we've already manually parsed BOARD_ID
             # if BOARD_ID threw an error, we want to try and parse the rest of the CAN message
             fields = CAN_MESSAGE.get_fields(msg_type)[4:]
-            data = _ParsleyParseInternal.parse_fields(BitString(msg_data), fields)
+            data = _ParsleyParseInternal.parse_fields(BitString(msg_data_bytes), fields)
         except (ValueError, IndexError, KeyError) as error:
             # convert the 6-bit msg_type into its canlib 12-bit form and include an error object
             return ParsleyError(
@@ -152,7 +152,7 @@ class _ParsleyParseInternal:
                 board_inst_id=board_inst_id,
                 msg_type=pu.hexify(encoded_msg_type, is_msg_type=True),
                 msg_metadata=msg_metadata,
-                msg_data=pu.hexify(msg_data),
+                msg_data=pu.hexify(msg_data_bytes),
                 error=f"error: {error}"
             )
             
@@ -169,32 +169,32 @@ class ParsleyParser(ABC):
     """ Abstract base for different input-format parsers """
 
     @abstractmethod
-    def parse(self, *args, **kwargs):
+    def parse(self, *args: Any, **kwargs: Any) -> Any:
         raise NotImplementedError("This class is an abstract class")
 
 class USBDebugParser(ParsleyParser):
     """ Parse ASCII USB-debug lines """
 
-    def parse(self, line: str) -> ParsleyObject | ParsleyError:
+    def parse(self, line: str) -> ParsleyObject[dict[str, Any]] | ParsleyError:
         line = line.strip(' \0\r\n')
         if len(line) == 0 or line[0] != '$':
             raise ValueError('Incorrect line format')
         line = line[1:]
 
         if ':' in line:
-            msg_sid, msg_data = line.split(':')
-            msg_sid_int = int(msg_sid, 16)
-            msg_data_list = [int(byte, 16) for byte in msg_data.split(',')]
+            msg_sid_str, msg_data_str = line.split(':')
+            msg_sid_int = int(msg_sid_str, 16)
+            msg_data_list = [int(byte, 16) for byte in msg_data_str.split(',')]
         else:
             msg_sid_int = int(line, 16)
-            msg_data_list = []
+            msg_data_list: list[int] = []
 
         return _ParsleyParseInternal.parse_to_object(msg_sid_int, msg_data_list)
 
 class LiveTelemetryParser(ParsleyParser):
     """ Parse binary live-telemetry """
 
-    def parse(self, frame: bytes) -> ParsleyObject | ParsleyError:
+    def parse(self, frame: bytes) -> ParsleyObject[dict[str, Any]] | ParsleyError:
         if len(frame) < 7:
             raise ValueError('Incorrect frame length')
         if frame[0] != 0x02:
@@ -204,7 +204,7 @@ class LiveTelemetryParser(ParsleyParser):
         msg_sid = int.from_bytes(bytes([frame[2] & 0x1F]) + frame[3:6], byteorder='big')
         msg_data = frame[6:frame_len-1]
         exp_crc = frame[frame_len-1]
-        msg_crc = crc8.crc8(frame[:frame_len-1]).digest()[0]
+        msg_crc: int = crc8.crc8(frame[:frame_len-1]).digest()[0]
 
         if msg_crc != exp_crc:
             raise ValueError(f'Bad checksum, expected {exp_crc:02X} but got {msg_crc:02X}')
@@ -233,7 +233,7 @@ class LoggerParser(ParsleyParser):
     HEADER_LEN = struct.calcsize(HEADER_FMT) # == 9
     PARSE_LOGGER_PAGE_SIZE = 4096
 
-    def parse(self, buf: bytes, page_number: int) -> ParsleyObject | ParsleyError:
+    def parse(self, buf: bytes, page_number: int) -> Generator[ParsleyObject[dict[str, Any]] | ParsleyError, None, None]:  # type: ignore[override]
         # Strip the buffer to 4096 bytes, as required by the logger.
         if len(buf) != self.PARSE_LOGGER_PAGE_SIZE:
             raise ValueError('Logger message must be exactly 4096 bytes')
@@ -264,7 +264,7 @@ class LoggerParser(ParsleyParser):
 class BitstringParser(ParsleyParser):
     ''' Parse BitString objects '''
 
-    def parse(self, bit_str: BitString) -> ParsleyObject | ParsleyError:
+    def parse(self, bit_str: BitString) -> ParsleyObject[dict[str, Any]] | ParsleyError:
         msg_sid = int.from_bytes(bit_str.pop(MESSAGE_SID.length), byteorder='big')
         msg_data = [byte for byte in bit_str.pop(bit_str.length)]
         return _ParsleyParseInternal.parse_to_object(msg_sid, msg_data)

--- a/src/parsley/parse_utils.py
+++ b/src/parsley/parse_utils.py
@@ -1,4 +1,5 @@
-def hexify(data: bytes, is_msg_type=False):
+# pyright: strict
+def hexify(data: bytes, is_msg_type: bool = False) -> str:
     """
     Formats byte strings into its respective hexadecimal strings.
 

--- a/src/parsley/parsley.py
+++ b/src/parsley/parsley.py
@@ -1,4 +1,6 @@
+# pyright: standard
 import crc8
+from collections.abc import Generator
 from typing import Any
 import struct
 from parsley.bitstring import BitString
@@ -48,7 +50,7 @@ def parse_bitstring(bit_str: BitString) -> tuple[bytes, bytes]:
     return format_can_message(msg_sid, list(msg_data))
 
 @deprecated(version='2026.2', reason="Deprecated; use LiveTelemetryParser.parse in the new LiveTelemetryParser object")
-def parse_live_telemetry(frame: bytes) -> tuple[bytes, bytes] | None:
+def parse_live_telemetry(frame: bytes) -> tuple[bytes, bytes]:
     if len(frame) < 7:   raise ValueError("Incorrect frame length")
     if frame[0] != 0x02: raise ValueError("Incorrect frame header")
 
@@ -64,7 +66,7 @@ def parse_live_telemetry(frame: bytes) -> tuple[bytes, bytes] | None:
     return format_can_message(msg_sid, list(msg_data))
 
 @deprecated(version='2026.2', reason="Deprecated; use USBDebugParser.parse in the new USBDebugParser object")
-def parse_usb_debug(line: str) -> tuple[bytes, bytes] | None:
+def parse_usb_debug(line: str) -> tuple[bytes, bytes]:
     line = line.strip(' \0\r\n')
     if len(line) == 0 or line[0] != '$':
         raise ValueError("Incorrect line format")
@@ -81,7 +83,7 @@ def parse_usb_debug(line: str) -> tuple[bytes, bytes] | None:
     return format_can_message(msg_sid, msg_data)
 
 @deprecated(version='2026.2', reason="Deprecated; use LoggerParser.parse in the new LoggerParser object")
-def parse_logger(buf: bytes, page_number: int) -> tuple[bytes, bytes] | None:
+def parse_logger(buf: bytes, page_number: int) -> Generator[tuple[bytes, bytes], None, None]:
     """
     Parse one logger record.
 

--- a/src/parsley/parsley_message.py
+++ b/src/parsley/parsley_message.py
@@ -1,5 +1,6 @@
+# pyright: strict
 from dataclasses import dataclass, asdict
-from typing import Generic, TypeVar
+from typing import Any, Generic, TypeVar
 from pydantic import BaseModel, field_validator
 import parsley.message_types as mt
 
@@ -21,7 +22,7 @@ class ParsleyError():
     msg_data: str
     error: str
 
-    def __getitem__(self, key: str):
+    def __getitem__(self, key: str) -> Any:
         return asdict(self)[key]
     
 class ParsleyObject(BaseModel, Generic[T]):
@@ -37,22 +38,25 @@ class ParsleyObject(BaseModel, Generic[T]):
     data: T # ParsleyDataType
 
     @field_validator("msg_prio")
-    def validate_msg_prio(cls, value):
+    @classmethod
+    def validate_msg_prio(cls, value: str) -> str:
         if value not in mt.msg_prio:
             raise ValueError(f"Invalid msg_prio type '{value}'")
         return value
     
     @field_validator("msg_type")
-    def validate_msg_type(cls, value):
+    @classmethod
+    def validate_msg_type(cls, value: str) -> str:
         if value not in mt.msg_type:
             raise ValueError(f"Invalid msg_type type '{value}'")
         return value
 
     @field_validator("msg_metadata")
-    def validate_msg_metadata(cls, value):
+    @classmethod
+    def validate_msg_metadata(cls, value: int) -> int:
         if not (0 <= value <= 255):
             raise ValueError(f"msg_metadata '{value}' is out of range (0-255)")
         return value
     
-    def __getitem__(self, key: str):        
+    def __getitem__(self, key: str) -> Any:        
         return self.model_dump()[key]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,2 @@
+# pyright: standard
 # don't mind this file, I (think I) need tests/ to be a module to import parsley/ things

--- a/tests/test_bitstring.py
+++ b/tests/test_bitstring.py
@@ -1,3 +1,4 @@
+# pyright: standard
 import pytest
 from parsley.bitstring import BitString
 

--- a/tests/test_can_metadata.py
+++ b/tests/test_can_metadata.py
@@ -1,3 +1,4 @@
+# pyright: standard
 import pytest
 import parsley
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,3 +1,4 @@
+# pyright: standard
 import pytest
 
 from parsley.fields import ASCII, Enum, Numeric, Switch, Floating, Bitfield
@@ -211,7 +212,7 @@ class TestSwitch:
     def test_switch(self):
         enum = {"a": 0x01, "b": 0x02, "c": 0x03}
         map_key_enum = {"a": [0, 1], "b": [1, 2], "c": [2, 3]}
-        switch = Switch("status", 8, enum, map_key_enum)
+        switch = Switch("status", 8, enum, map_key_enum)  # pyright: ignore[reportArgumentType]
         (data, length) = switch.encode("a")
         assert data == b"\x01"
         assert length == 8

--- a/tests/test_message_definitions.py
+++ b/tests/test_message_definitions.py
@@ -1,3 +1,4 @@
+# pyright: standard
 import pytest
 import parsley
 

--- a/tests/test_parse_to_object.py
+++ b/tests/test_parse_to_object.py
@@ -1,3 +1,4 @@
+# pyright: standard
 import pytest
 
 from parsley.bitstring import BitString
@@ -414,7 +415,7 @@ class TestParseToObject:
     
         frame[1] = len(frame) + 1  #makes length +1 cause cyclic redundancy check byte
         
-        crc = crc8.crc8(frame).digest()[0]
+        crc = crc8.crc8(bytes(frame)).digest()[0]
         frame.append(crc) #actually adds the crc byte
 
         result = LiveTelemetryParser().parse(bytes(frame))

--- a/tests/test_parsley.py
+++ b/tests/test_parsley.py
@@ -1,3 +1,4 @@
+# pyright: standard
 import parsley
 import pytest
 
@@ -393,7 +394,7 @@ class TestParsley:
     
         frame[1] = len(frame) + 1  #makes length +1 cause cyclic redundancy check byte
         
-        crc = crc8.crc8(frame).digest()[0]
+        crc = crc8.crc8(bytes(frame)).digest()[0]
         frame.append(crc) #actually adds the crc byte
 
         msg_sid, msg_data = parsley.parse_live_telemetry(bytes(frame))

--- a/tests/test_parsley_message.py
+++ b/tests/test_parsley_message.py
@@ -1,3 +1,4 @@
+# pyright: standard
 import pytest
 from pydantic import ValidationError
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,4 @@
+# pyright: standard
 import pytest
 
 from parsley.bitstring import BitString

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,3 +1,4 @@
+# pyright: standard
 import pytest
 
 from parsley.bitstring import BitString


### PR DESCRIPTION
## Summary

Adds per-file pyright type checking annotations and fixes all type errors.

### Changes

- **`# pyright: strict`** on all `src/parsley/` modules (except `parsley.py`)
- **`# pyright: standard`** on `parsley.py` (legacy API) and all test files
- Fixes all type errors reported by basedpyright (from 89 → 0 errors)

### Key fixes
- Modernized typing imports (`Tuple`→`tuple`, `Union`→`|`, `Optional`→`| None`)
- Added missing type annotations to function params and return types
- Fixed variable type reassignment issues (pyright strict flags reassigning to different type)
- Added Generic type args to `ParsleyObject[dict[str, Any]]`
- Fixed `parse_to_object` to accept `bytes | int` for msg_sid and `bytes | list[int]` for msg_data
- Fixed `parse_logger` return type to `Generator` (was incorrectly annotated as non-generator)
- Removed incorrect `| None` from legacy parse function return types
- Added `@classmethod` decorators to pydantic validators
- Suppressed crc8 missing stubs warning

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/parsley/63)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Parser methods (`parse_live_telemetry`, `parse_usb_debug`) no longer return `None`; `parse_logger` now uses generator-based iteration for improved data streaming.

* **Chores**
  * Added "deprecated" dependency to requirements.
  * Enhanced code quality and validation throughout the library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->