### PR TITLE
Fix metadata not printing bug + other 2026.3 issues

### DIFF
--- a/src/parsley/parse_to_object.py
+++ b/src/parsley/parse_to_object.py
@@ -1,7 +1,7 @@
 '''
 Contains the new static class implementation of Parsley.py
 '''
-from typing import Any, Generator
+from typing import Any
 from parsley.parsley_message import ParsleyObject, ParsleyError
 from parsley.bitstring import BitString
 from parsley.message_definitions import CAN_MESSAGE, MESSAGE_PRIO, MESSAGE_TYPE, BOARD_TYPE_ID, BOARD_INST_ID, MESSAGE_METADATA, MESSAGE_SID
@@ -17,16 +17,7 @@ MSG_PRIO_LEN = max([len(msg_prio) for msg_prio in mt.msg_prio])
 MSG_TYPE_LEN = max([len(msg_type) for msg_type in mt.msg_type])
 BOARD_TYPE_ID_LEN = max([len(board_type_id) for board_type_id in mt.board_type_id])
 BOARD_INST_ID_LEN = max([len(board_inst_id) for board_inst_id in mt.board_inst_id])
-# Widest name across every per-msg-type metadata Enum. The parser already resolves
-# the 8-bit metadata to a name string when CAN_MESSAGE has an Enum at index 3
-# (e.g. SENSOR_ANALOG16 -> 'SENSOR_5V_VOLT'), otherwise it stays a numeric int.
-MSG_METADATA_LEN = max(
-    (len(name)
-     for fields in CAN_MESSAGE.map_key_enum.values()
-     if isinstance(fields[3], Enum)
-     for name in fields[3].map_key_val),
-    default=0,
-)
+MSG_METADATA_LEN = max((len(name) for fields in CAN_MESSAGE.map_key_enum.values() if isinstance(fields[3], Enum) for name in fields[3].map_key_val), default=0)
 
 class _ParsleyParseInternal:
     def __init__(self):
@@ -38,13 +29,15 @@ class _ParsleyParseInternal:
         msg_type = parsed_data['msg_type']
         board_type_id = parsed_data['board_type_id']
         board_inst_id = parsed_data['board_inst_id']
-        msg_metadata = parsed_data.get('msg_metadata', '')
+        msg_metadata = parsed_data['msg_metadata']
         data = parsed_data['data']
+        
         res = (
             f'[ {msg_prio:<{MSG_PRIO_LEN}} {msg_type:<{MSG_TYPE_LEN}}'
             f' {board_type_id:<{BOARD_TYPE_ID_LEN}} {board_inst_id:<{BOARD_INST_ID_LEN}}'
             f' {str(msg_metadata):<{MSG_METADATA_LEN}} ]'
         )
+        
         for k, v in data.items():
             formatted_value = f"{v:.3f}" if isinstance(v, float) else v
             res += f' {k}: {formatted_value}'
@@ -70,32 +63,16 @@ class _ParsleyParseInternal:
         bit_str.push(*MESSAGE_TYPE.encode(msg_type))
         bit_str.push(*BOARD_TYPE_ID.encode(board_type_id))
         bit_str.push(*BOARD_INST_ID.encode(board_inst_id))
-        # The parser falls back to a raw int when an Enum-typed metadata byte
-        # doesn't match any known key (parse_msg_metadata). Mirror that on the
-        # encode side: if the field is an Enum but we have an int, push the
-        # raw byte through MESSAGE_METADATA so a corrupt-but-known msg_type can
-        # still be re-emitted unchanged.
         metadata_field = CAN_MESSAGE.get_fields(msg_type)[3]
-        if isinstance(metadata_field, Enum) and isinstance(msg_metadata, int):
+        if isinstance(metadata_field, Enum) and type(msg_metadata) is int:
             bit_str.push(*MESSAGE_METADATA.encode(msg_metadata))
         else:
             bit_str.push(*metadata_field.encode(msg_metadata))
         msg_sid = int.from_bytes(bit_str.pop(bit_str.length), byteorder='big')
 
-        # Accept both the flat shape (legacy hand-built dicts) and the nested
-        # `{'data': {...}}` shape that the parser actually produces. Looking up
-        # payload fields at the top level lets callers like FakeSerialCommunicator
-        # / commander.py keep working; the `data` fallback lets `parse → encode`
-        # round-trip a ParsleyObject.model_dump().
-        payload = parsed_data.get('data') if isinstance(parsed_data.get('data'), dict) else None
+        # skip the first field (board_id) since thats parsed separately
         for field in CAN_MESSAGE.get_fields(msg_type)[4:]:
-            if field.name in parsed_data:
-                value = parsed_data[field.name]
-            elif payload is not None and field.name in payload:
-                value = payload[field.name]
-            else:
-                raise KeyError(field.name)
-            bit_str.push(*field.encode(value))
+            bit_str.push(*field.encode(parsed_data[field.name]))
         msg_data = [byte for byte in bit_str.pop(bit_str.length)]
         return msg_sid, msg_data
 
@@ -280,7 +257,7 @@ class LoggerParser(ParsleyParser):
     HEADER_LEN = struct.calcsize(HEADER_FMT) # == 9
     PARSE_LOGGER_PAGE_SIZE = 4096
 
-    def parse(self, buf: bytes, page_number: int) -> Generator[ParsleyObject | ParsleyError, None, None]:
+    def parse(self, buf: bytes, page_number: int) -> ParsleyObject | ParsleyError:
         # Strip the buffer to 4096 bytes, as required by the logger.
         if len(buf) != self.PARSE_LOGGER_PAGE_SIZE:
             raise ValueError('Logger message must be exactly 4096 bytes')

--- a/src/parsley/parse_to_object.py
+++ b/src/parsley/parse_to_object.py
@@ -1,12 +1,12 @@
 '''
 Contains the new static class implementation of Parsley.py
 '''
-from typing import Any
+from typing import Any, Generator
 from parsley.parsley_message import ParsleyObject, ParsleyError
 from parsley.bitstring import BitString
 from parsley.message_definitions import CAN_MESSAGE, MESSAGE_PRIO, MESSAGE_TYPE, BOARD_TYPE_ID, BOARD_INST_ID, MESSAGE_METADATA, MESSAGE_SID
 import parsley.parse_utils as pu
-from parsley.fields import Field, Switch, Bitfield
+from parsley.fields import Field, Switch, Bitfield, Enum
 from abc import ABC, abstractmethod
 import struct
 import crc8
@@ -17,6 +17,16 @@ MSG_PRIO_LEN = max([len(msg_prio) for msg_prio in mt.msg_prio])
 MSG_TYPE_LEN = max([len(msg_type) for msg_type in mt.msg_type])
 BOARD_TYPE_ID_LEN = max([len(board_type_id) for board_type_id in mt.board_type_id])
 BOARD_INST_ID_LEN = max([len(board_inst_id) for board_inst_id in mt.board_inst_id])
+# Widest name across every per-msg-type metadata Enum. The parser already resolves
+# the 8-bit metadata to a name string when CAN_MESSAGE has an Enum at index 3
+# (e.g. SENSOR_ANALOG16 -> 'SENSOR_5V_VOLT'), otherwise it stays a numeric int.
+MSG_METADATA_LEN = max(
+    (len(name)
+     for fields in CAN_MESSAGE.map_key_enum.values()
+     if isinstance(fields[3], Enum)
+     for name in fields[3].map_key_val),
+    default=0,
+)
 
 class _ParsleyParseInternal:
     def __init__(self):
@@ -28,8 +38,13 @@ class _ParsleyParseInternal:
         msg_type = parsed_data['msg_type']
         board_type_id = parsed_data['board_type_id']
         board_inst_id = parsed_data['board_inst_id']
+        msg_metadata = parsed_data.get('msg_metadata', '')
         data = parsed_data['data']
-        res = f'[ {msg_prio:<{MSG_PRIO_LEN}} {msg_type:<{MSG_TYPE_LEN}} {board_type_id:<{BOARD_TYPE_ID_LEN}} {board_inst_id:<{BOARD_INST_ID_LEN}} ]'
+        res = (
+            f'[ {msg_prio:<{MSG_PRIO_LEN}} {msg_type:<{MSG_TYPE_LEN}}'
+            f' {board_type_id:<{BOARD_TYPE_ID_LEN}} {board_inst_id:<{BOARD_INST_ID_LEN}}'
+            f' {str(msg_metadata):<{MSG_METADATA_LEN}} ]'
+        )
         for k, v in data.items():
             formatted_value = f"{v:.3f}" if isinstance(v, float) else v
             res += f' {k}: {formatted_value}'
@@ -55,12 +70,32 @@ class _ParsleyParseInternal:
         bit_str.push(*MESSAGE_TYPE.encode(msg_type))
         bit_str.push(*BOARD_TYPE_ID.encode(board_type_id))
         bit_str.push(*BOARD_INST_ID.encode(board_inst_id))
-        bit_str.push(*CAN_MESSAGE.get_fields(msg_type)[3].encode(msg_metadata))
+        # The parser falls back to a raw int when an Enum-typed metadata byte
+        # doesn't match any known key (parse_msg_metadata). Mirror that on the
+        # encode side: if the field is an Enum but we have an int, push the
+        # raw byte through MESSAGE_METADATA so a corrupt-but-known msg_type can
+        # still be re-emitted unchanged.
+        metadata_field = CAN_MESSAGE.get_fields(msg_type)[3]
+        if isinstance(metadata_field, Enum) and isinstance(msg_metadata, int):
+            bit_str.push(*MESSAGE_METADATA.encode(msg_metadata))
+        else:
+            bit_str.push(*metadata_field.encode(msg_metadata))
         msg_sid = int.from_bytes(bit_str.pop(bit_str.length), byteorder='big')
 
-        # skip the first field (board_id) since thats parsed separately
+        # Accept both the flat shape (legacy hand-built dicts) and the nested
+        # `{'data': {...}}` shape that the parser actually produces. Looking up
+        # payload fields at the top level lets callers like FakeSerialCommunicator
+        # / commander.py keep working; the `data` fallback lets `parse → encode`
+        # round-trip a ParsleyObject.model_dump().
+        payload = parsed_data.get('data') if isinstance(parsed_data.get('data'), dict) else None
         for field in CAN_MESSAGE.get_fields(msg_type)[4:]:
-            bit_str.push(*field.encode(parsed_data[field.name]))
+            if field.name in parsed_data:
+                value = parsed_data[field.name]
+            elif payload is not None and field.name in payload:
+                value = payload[field.name]
+            else:
+                raise KeyError(field.name)
+            bit_str.push(*field.encode(value))
         msg_data = [byte for byte in bit_str.pop(bit_str.length)]
         return msg_sid, msg_data
 
@@ -159,6 +194,7 @@ class _ParsleyParseInternal:
         except (ValueError, IndexError, KeyError) as error:
             # convert the 6-bit msg_type into its canlib 12-bit form and include an error object
             return ParsleyError(
+                msg_prio=msg_prio,
                 board_type_id=board_type_id,
                 board_inst_id=board_inst_id,
                 msg_type=pu.hexify(encoded_msg_type, is_msg_type=True),
@@ -244,7 +280,7 @@ class LoggerParser(ParsleyParser):
     HEADER_LEN = struct.calcsize(HEADER_FMT) # == 9
     PARSE_LOGGER_PAGE_SIZE = 4096
 
-    def parse(self, buf: bytes, page_number: int) -> ParsleyObject | ParsleyError:
+    def parse(self, buf: bytes, page_number: int) -> Generator[ParsleyObject | ParsleyError, None, None]:
         # Strip the buffer to 4096 bytes, as required by the logger.
         if len(buf) != self.PARSE_LOGGER_PAGE_SIZE:
             raise ValueError('Logger message must be exactly 4096 bytes')

--- a/src/parsley/parsley.py
+++ b/src/parsley/parsley.py
@@ -30,9 +30,11 @@ def parse(msg_sid: bytes, msg_data: bytes) -> dict:
     
     if isinstance(result, ParsleyError):
         return {
+            'msg_prio': result.msg_prio,
             'board_type_id': result.board_type_id,
             'board_inst_id': result.board_inst_id,
             'msg_type': result.msg_type,
+            'msg_metadata': result.msg_metadata,
             'data': {
                 'msg_data': result.msg_data,
                 'error': result.error

--- a/src/parsley/parsley_message.py
+++ b/src/parsley/parsley_message.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, asdict
 from typing import Generic, TypeVar
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, field_validator, model_validator
 import parsley.message_types as mt
 
 T = TypeVar("T")
@@ -11,9 +11,28 @@ MsgPrio = str
 MsgType = str
 MsgMetadata = int | str
 
+# Per-msg-type metadata enum mapping. Mirrors the index-3 field of each
+# msg_type in CAN_MESSAGE (parsley.message_definitions). Kept here as a
+# literal table to avoid pulling message_definitions into this module —
+# message_definitions imports parsley.fields which doesn't import this
+# file, but importing CAN_MESSAGE would couple the validators to the
+# wire-format module unnecessarily. If a new msg_type with an Enum
+# metadata byte is added to MESSAGES, add it here too.
+_METADATA_ENUM_BY_MSG_TYPE: dict[str, dict[str, int]] = {
+    'ACTUATOR_CMD':       mt.actuator_id,
+    'ACTUATOR_STATUS':    mt.actuator_id,
+    'ALT_ARM_CMD':        mt.altimeter_id,
+    'ALT_ARM_STATUS':     mt.altimeter_id,
+    'SENSOR_ANALOG16':    mt.analog_sensor_id,
+    'SENSOR_ANALOG32':    mt.analog_sensor_id,
+    'SENSOR_2D_ANALOG24': mt.dem_2d_sensor_id,
+    'SENSOR_3D_ANALOG16': mt.dem_3d_sensor_id,
+}
+
 @dataclass
 class ParsleyError():
     """Custom error container for Parsley errors."""
+    msg_prio: MsgPrio
     board_type_id: BoardTypeID
     board_inst_id: BoardInstID
     msg_type: MsgType
@@ -38,10 +57,16 @@ class ParsleyObject(BaseModel, Generic[T]):
 
     @field_validator("msg_prio")
     def validate_msg_prio(cls, value):
-        if len(value) == 0:
-            raise ValueError('msg_prio must be non-empty')
+        # MESSAGE_PRIO is a 2-bit Enum with all 4 values mapped, so the parser
+        # will always emit a value from mt.msg_prio. Any other string is a
+        # caller-side mistake — accepting it silently used to mask bugs like
+        # callers passing the hexified bytes `'0x03'` instead of the name `'LOW'`.
+        if value not in mt.msg_prio:
+            raise ValueError(
+                f"Invalid msg_prio '{value}' (expected one of {list(mt.msg_prio)})"
+            )
         return value
-    
+
     @field_validator("msg_type")
     def validate_msg_type(cls, value):
         if value not in mt.msg_type:
@@ -50,6 +75,9 @@ class ParsleyObject(BaseModel, Generic[T]):
 
     @field_validator("msg_metadata")
     def validate_msg_metadata(cls, value):
+        # Field-level validation: shape + numeric range. The semantic check
+        # (string value is a valid key in the per-msg-type enum) needs
+        # msg_type, so it runs in the model-level validator below.
         if isinstance(value, int):
             if not (0 <= value <= 255):
                 raise ValueError(f"msg_metadata '{value}' is out of range (0-255)")
@@ -59,6 +87,30 @@ class ParsleyObject(BaseModel, Generic[T]):
         else:
             raise ValueError('msg_metadata must be int or str')
         return value
-    
-    def __getitem__(self, key: str):        
+
+    @model_validator(mode='after')
+    def validate_msg_metadata_against_msg_type(self):
+        # Cross-check the metadata value against the msg_type's expected enum.
+        # The parser falls back to an int byte (0-255) when an Enum-typed
+        # metadata decode fails on a corrupt frame, so int values are always
+        # accepted regardless of msg_type. But a string value must be a real
+        # key in the matching enum — otherwise encode_data would crash later
+        # at re-emit time, and the bad value would silently propagate through
+        # consumers that branch on the metadata string.
+        if isinstance(self.msg_metadata, str):
+            enum_map = _METADATA_ENUM_BY_MSG_TYPE.get(self.msg_type)
+            if enum_map is None:
+                raise ValueError(
+                    f"msg_metadata is a string ('{self.msg_metadata}') but msg_type "
+                    f"'{self.msg_type}' uses a numeric metadata byte"
+                )
+            if self.msg_metadata not in enum_map:
+                raise ValueError(
+                    f"msg_metadata '{self.msg_metadata}' is not a valid key for "
+                    f"msg_type '{self.msg_type}' "
+                    f"(expected a name from {list(enum_map.keys())[:3]}…)"
+                )
+        return self
+
+    def __getitem__(self, key: str):
         return self.model_dump()[key]

--- a/src/parsley/parsley_message.py
+++ b/src/parsley/parsley_message.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass, asdict
 from typing import Generic, TypeVar
 from pydantic import BaseModel, field_validator, model_validator
 import parsley.message_types as mt
+from parsley.message_definitions import CAN_MESSAGE
+from parsley.fields import Enum as _Enum
 
 T = TypeVar("T")
 
@@ -10,24 +12,6 @@ BoardInstID = str
 MsgPrio = str
 MsgType = str
 MsgMetadata = int | str
-
-# Per-msg-type metadata enum mapping. Mirrors the index-3 field of each
-# msg_type in CAN_MESSAGE (parsley.message_definitions). Kept here as a
-# literal table to avoid pulling message_definitions into this module —
-# message_definitions imports parsley.fields which doesn't import this
-# file, but importing CAN_MESSAGE would couple the validators to the
-# wire-format module unnecessarily. If a new msg_type with an Enum
-# metadata byte is added to MESSAGES, add it here too.
-_METADATA_ENUM_BY_MSG_TYPE: dict[str, dict[str, int]] = {
-    'ACTUATOR_CMD':       mt.actuator_id,
-    'ACTUATOR_STATUS':    mt.actuator_id,
-    'ALT_ARM_CMD':        mt.altimeter_id,
-    'ALT_ARM_STATUS':     mt.altimeter_id,
-    'SENSOR_ANALOG16':    mt.analog_sensor_id,
-    'SENSOR_ANALOG32':    mt.analog_sensor_id,
-    'SENSOR_2D_ANALOG24': mt.dem_2d_sensor_id,
-    'SENSOR_3D_ANALOG16': mt.dem_3d_sensor_id,
-}
 
 @dataclass
 class ParsleyError():
@@ -57,10 +41,6 @@ class ParsleyObject(BaseModel, Generic[T]):
 
     @field_validator("msg_prio")
     def validate_msg_prio(cls, value):
-        # MESSAGE_PRIO is a 2-bit Enum with all 4 values mapped, so the parser
-        # will always emit a value from mt.msg_prio. Any other string is a
-        # caller-side mistake — accepting it silently used to mask bugs like
-        # callers passing the hexified bytes `'0x03'` instead of the name `'LOW'`.
         if value not in mt.msg_prio:
             raise ValueError(
                 f"Invalid msg_prio '{value}' (expected one of {list(mt.msg_prio)})"
@@ -75,10 +55,7 @@ class ParsleyObject(BaseModel, Generic[T]):
 
     @field_validator("msg_metadata")
     def validate_msg_metadata(cls, value):
-        # Field-level validation: shape + numeric range. The semantic check
-        # (string value is a valid key in the per-msg-type enum) needs
-        # msg_type, so it runs in the model-level validator below.
-        if isinstance(value, int):
+        if type(value) is int:
             if not (0 <= value <= 255):
                 raise ValueError(f"msg_metadata '{value}' is out of range (0-255)")
         elif isinstance(value, str):
@@ -90,25 +67,18 @@ class ParsleyObject(BaseModel, Generic[T]):
 
     @model_validator(mode='after')
     def validate_msg_metadata_against_msg_type(self):
-        # Cross-check the metadata value against the msg_type's expected enum.
-        # The parser falls back to an int byte (0-255) when an Enum-typed
-        # metadata decode fails on a corrupt frame, so int values are always
-        # accepted regardless of msg_type. But a string value must be a real
-        # key in the matching enum — otherwise encode_data would crash later
-        # at re-emit time, and the bad value would silently propagate through
-        # consumers that branch on the metadata string.
         if isinstance(self.msg_metadata, str):
-            enum_map = _METADATA_ENUM_BY_MSG_TYPE.get(self.msg_type)
-            if enum_map is None:
+            metadata_field = CAN_MESSAGE.get_fields(self.msg_type)[3]
+            if not isinstance(metadata_field, _Enum):
                 raise ValueError(
                     f"msg_metadata is a string ('{self.msg_metadata}') but msg_type "
                     f"'{self.msg_type}' uses a numeric metadata byte"
                 )
-            if self.msg_metadata not in enum_map:
+            if self.msg_metadata not in metadata_field.map_key_val:
                 raise ValueError(
                     f"msg_metadata '{self.msg_metadata}' is not a valid key for "
                     f"msg_type '{self.msg_type}' "
-                    f"(expected a name from {list(enum_map.keys())[:3]}…)"
+                    f"(expected a name from {list(metadata_field.map_key_val.keys())[:3]}…)"
                 )
         return self
 

--- a/tests/test_parse_to_object.py
+++ b/tests/test_parse_to_object.py
@@ -355,21 +355,64 @@ class TestParseToObject:
         assert bit_len == 70
         
     def test_format_line(self):
+        # Structural check: substring `'X' in line` would still pass even if
+        # format_line silently dropped a column (that's the exact pattern that
+        # hid the original msg_metadata drop). Split the formatted line back
+        # into its header list + body dict and compare positionally, so any
+        # drop/reorder/extra-field surfaces immediately.
         parsed_data = {
             'msg_prio': 'HIGH',
             'msg_type': 'GENERAL_BOARD_STATUS',
             'board_type_id': 'RLCS_RELAY',
             'board_inst_id': 'ROCKET',
+            'msg_metadata': 0,
             'data': {
                 'time': 1.234,
                 'board_error_bitfield': 'E_5V_OVER_VOLTAGE|E_5V_EFUSE_FAULT'
             }
         }
         line = _ParsleyParseInternal.format_line(parsed_data)
-        # MSG_PRIO_LEN=7 (HIGHEST), MSG_TYPE_LEN=20 (GENERAL_BOARD_STATUS),
-        # BOARD_TYPE_ID_LEN=10 (RLCS_RELAY), BOARD_INST_ID_LEN=15 (RA_STRATOLOGGER)
-        expected_line = '[ HIGH    GENERAL_BOARD_STATUS   RLCS_RELAY ROCKET          ] time: 1.234 board_error_bitfield: E_5V_OVER_VOLTAGE|E_5V_EFUSE_FAULT'
-        assert line == expected_line
+        header, body = utilities.split_format_line(line)
+        assert header == ['HIGH', 'GENERAL_BOARD_STATUS', 'RLCS_RELAY', 'ROCKET', '0']
+        assert body == {'time': '1.234', 'board_error_bitfield': 'E_5V_OVER_VOLTAGE|E_5V_EFUSE_FAULT'}
+
+    def test_format_line_includes_sensor_metadata(self):
+        # SENSOR_ANALOG16 uses Enum(analog_sensor_id) at index 3, so the parser
+        # produces 'SENSOR_PT_CHANNEL_1' as a string for msg_metadata.
+        parsed_data = {
+            'msg_prio': 'LOW',
+            'msg_type': 'SENSOR_ANALOG16',
+            'board_type_id': 'LOGGER',
+            'board_inst_id': 'ROCKET',
+            'msg_metadata': 'SENSOR_PT_CHANNEL_1',
+            'data': {'time': 22.473, 'value': 13923},
+        }
+        line = _ParsleyParseInternal.format_line(parsed_data)
+        assert 'SENSOR_PT_CHANNEL_1' in line
+
+    def test_format_line_includes_actuator_metadata(self):
+        parsed_data = {
+            'msg_prio': 'MEDIUM',
+            'msg_type': 'ACTUATOR_CMD',
+            'board_type_id': 'INJECTOR',
+            'board_inst_id': 'ROCKET',
+            'msg_metadata': next(iter(mt.actuator_id)),
+            'data': {'time': 1.0, 'cmd_state': next(iter(mt.actuator_state))},
+        }
+        line = _ParsleyParseInternal.format_line(parsed_data)
+        assert next(iter(mt.actuator_id)) in line
+
+    def test_format_line_includes_altimeter_metadata(self):
+        parsed_data = {
+            'msg_prio': 'MEDIUM',
+            'msg_type': 'ALT_ARM_CMD',
+            'board_type_id': 'PAYLOAD',
+            'board_inst_id': 'ROCKET',
+            'msg_metadata': next(iter(mt.altimeter_id)),
+            'data': {'time': 1.0, 'alt_arm_state': next(iter(mt.alt_arm_state))},
+        }
+        line = _ParsleyParseInternal.format_line(parsed_data)
+        assert next(iter(mt.altimeter_id)) in line
         
     def test_encode_data(self):
         parsed_data = {
@@ -415,6 +458,71 @@ class TestParseToObject:
 
         assert res['msg_metadata'] == 'ACTUATOR_FUEL_INJECTOR_VALVE'
         assert res['msg_type'] == 'ACTUATOR_CMD'
+
+    def test_encode_round_trips_parser_output(self):
+        # The shape the parser actually produces (nested 'data' dict) must be
+        # accepted by encode_data. Pre-2026.3 only the flat hand-built shape
+        # worked, so a parse→encode round-trip silently failed.
+        msg_sid = utilities.create_msg_sid_from_strings(
+            'MEDIUM', 'ALT_ARM_STATUS', '0', 'ALTIMETER', 'ROCKET'
+        )
+        bit_str = BitString()
+        bit_str.push(*TIMESTAMP_2.encode(0.0))  # exact-encoding timestamp value
+        bit_str.push(*Enum('alt_arm_state', 8, mt.alt_arm_state).encode('ALT_ARM_STATE_ARMED'))
+        bit_str.push(*Numeric('drogue_v', 16).encode(4095))
+        bit_str.push(*Numeric('main_v', 16).encode(2048))
+        msg_data = bit_str.pop(bit_str.length)
+
+        parsed = _ParsleyParseInternal.parse_to_object(msg_sid, msg_data)
+        assert isinstance(parsed, ParsleyObject)
+        dumped = parsed.model_dump()
+
+        # Round-trip the parser's own output shape — this is what omnibus
+        # consumers receive over CAN/Parsley.
+        re_sid, re_data = _ParsleyParseInternal.encode_data(dumped)
+        assert int.from_bytes(re_sid.to_bytes(4, 'big'), 'big') == int.from_bytes(msg_sid, 'big')
+        assert bytes(re_data) == bytes(msg_data)
+
+    def test_encode_corrupt_metadata_falls_back_to_numeric(self):
+        # The parser falls back to a raw int byte when an Enum-typed metadata
+        # decode fails. encode_data must accept that same int so a corrupt
+        # frame can be forwarded without first sanitizing it.
+        bit_sid = BitString()
+        bit_sid.push(*MESSAGE_PRIO.encode('HIGH'))
+        bit_sid.push(*MESSAGE_TYPE.encode('ACTUATOR_CMD'))
+        bit_sid.push(*BOARD_TYPE_ID.encode('INJECTOR'))
+        bit_sid.push(*BOARD_INST_ID.encode('ROCKET'))
+        bit_sid.push(*MESSAGE_METADATA.encode(0xFF))  # not a valid actuator_id
+        msg_sid = bit_sid.pop(MESSAGE_SID.length)
+
+        bit_data = BitString()
+        bit_data.push(*TIMESTAMP_2.encode(0.0))  # Numeric.encode has float-precision issues at non-zero scaled values
+        bit_data.push(*Enum('cmd_state', 8, mt.actuator_state).encode('ACT_STATE_ON'))
+        msg_data = bit_data.pop(bit_data.length)
+
+        parsed = _ParsleyParseInternal.parse_to_object(msg_sid, msg_data)
+        assert isinstance(parsed, ParsleyObject)
+        assert parsed.msg_metadata == 0xFF  # fell back to int
+
+        # Round-trip the int-valued metadata
+        re_sid, re_data = _ParsleyParseInternal.encode_data(parsed.model_dump())
+        assert bytes(re_data) == bytes(msg_data)
+
+    def test_parsley_error_carries_msg_prio(self):
+        # ParsleyError must include msg_prio so consumers branching on error
+        # can still observe priority. Trigger an error by giving a bad SID
+        # that decodes msg_prio successfully but fails on msg_type.
+        bit_sid = BitString()
+        bit_sid.push(*MESSAGE_PRIO.encode('LOW'))
+        bit_sid.push(b'\x7F', MESSAGE_TYPE.length)  # 0x7F is not a known msg_type
+        bit_sid.push(*BOARD_TYPE_ID.encode('GPS'))
+        bit_sid.push(*BOARD_INST_ID.encode('ROCKET'))
+        bit_sid.push(*MESSAGE_METADATA.encode(0))
+        msg_sid = bit_sid.pop(MESSAGE_SID.length)
+
+        result = _ParsleyParseInternal.parse_to_object(msg_sid, b'')
+        assert isinstance(result, ParsleyError)
+        assert result.msg_prio == 'LOW'
 
     def test_parse_usb_debug(self):
         line = "$1234ABCD:12,34,56,78\r\n\0"

--- a/tests/test_parse_to_object.py
+++ b/tests/test_parse_to_object.py
@@ -355,11 +355,6 @@ class TestParseToObject:
         assert bit_len == 70
         
     def test_format_line(self):
-        # Structural check: substring `'X' in line` would still pass even if
-        # format_line silently dropped a column (that's the exact pattern that
-        # hid the original msg_metadata drop). Split the formatted line back
-        # into its header list + body dict and compare positionally, so any
-        # drop/reorder/extra-field surfaces immediately.
         parsed_data = {
             'msg_prio': 'HIGH',
             'msg_type': 'GENERAL_BOARD_STATUS',
@@ -377,8 +372,7 @@ class TestParseToObject:
         assert body == {'time': '1.234', 'board_error_bitfield': 'E_5V_OVER_VOLTAGE|E_5V_EFUSE_FAULT'}
 
     def test_format_line_includes_sensor_metadata(self):
-        # SENSOR_ANALOG16 uses Enum(analog_sensor_id) at index 3, so the parser
-        # produces 'SENSOR_PT_CHANNEL_1' as a string for msg_metadata.
+        # SENSOR_ANALOG16 should have'SENSOR_PT_CHANNEL_1' as a string for msg_metadata.
         parsed_data = {
             'msg_prio': 'LOW',
             'msg_type': 'SENSOR_ANALOG16',
@@ -459,59 +453,26 @@ class TestParseToObject:
         assert res['msg_metadata'] == 'ACTUATOR_FUEL_INJECTOR_VALVE'
         assert res['msg_type'] == 'ACTUATOR_CMD'
 
-    def test_encode_round_trips_parser_output(self):
-        # The shape the parser actually produces (nested 'data' dict) must be
-        # accepted by encode_data. Pre-2026.3 only the flat hand-built shape
-        # worked, so a parse→encode round-trip silently failed.
-        msg_sid = utilities.create_msg_sid_from_strings(
-            'MEDIUM', 'ALT_ARM_STATUS', '0', 'ALTIMETER', 'ROCKET'
-        )
-        bit_str = BitString()
-        bit_str.push(*TIMESTAMP_2.encode(0.0))  # exact-encoding timestamp value
-        bit_str.push(*Enum('alt_arm_state', 8, mt.alt_arm_state).encode('ALT_ARM_STATE_ARMED'))
-        bit_str.push(*Numeric('drogue_v', 16).encode(4095))
-        bit_str.push(*Numeric('main_v', 16).encode(2048))
-        msg_data = bit_str.pop(bit_str.length)
-
-        parsed = _ParsleyParseInternal.parse_to_object(msg_sid, msg_data)
-        assert isinstance(parsed, ParsleyObject)
-        dumped = parsed.model_dump()
-
-        # Round-trip the parser's own output shape — this is what omnibus
-        # consumers receive over CAN/Parsley.
-        re_sid, re_data = _ParsleyParseInternal.encode_data(dumped)
-        assert int.from_bytes(re_sid.to_bytes(4, 'big'), 'big') == int.from_bytes(msg_sid, 'big')
-        assert bytes(re_data) == bytes(msg_data)
-
     def test_encode_corrupt_metadata_falls_back_to_numeric(self):
-        # The parser falls back to a raw int byte when an Enum-typed metadata
-        # decode fails. encode_data must accept that same int so a corrupt
-        # frame can be forwarded without first sanitizing it.
-        bit_sid = BitString()
-        bit_sid.push(*MESSAGE_PRIO.encode('HIGH'))
-        bit_sid.push(*MESSAGE_TYPE.encode('ACTUATOR_CMD'))
-        bit_sid.push(*BOARD_TYPE_ID.encode('INJECTOR'))
-        bit_sid.push(*BOARD_INST_ID.encode('ROCKET'))
-        bit_sid.push(*MESSAGE_METADATA.encode(0xFF))  # not a valid actuator_id
-        msg_sid = bit_sid.pop(MESSAGE_SID.length)
+        flat = {
+            'msg_prio': 'HIGH',
+            'msg_type': 'ACTUATOR_CMD',
+            'board_type_id': 'INJECTOR',
+            'board_inst_id': 'ROCKET',
+            'msg_metadata': 0xFF,  # not a valid actuator_id name
+            'time': 0.0,
+            'cmd_state': 'ACT_STATE_ON',
+        }
+        msg_sid, _ = _ParsleyParseInternal.encode_data(flat)
 
-        bit_data = BitString()
-        bit_data.push(*TIMESTAMP_2.encode(0.0))  # Numeric.encode has float-precision issues at non-zero scaled values
-        bit_data.push(*Enum('cmd_state', 8, mt.actuator_state).encode('ACT_STATE_ON'))
-        msg_data = bit_data.pop(bit_data.length)
-
-        parsed = _ParsleyParseInternal.parse_to_object(msg_sid, msg_data)
-        assert isinstance(parsed, ParsleyObject)
-        assert parsed.msg_metadata == 0xFF  # fell back to int
-
-        # Round-trip the int-valued metadata
-        re_sid, re_data = _ParsleyParseInternal.encode_data(parsed.model_dump())
-        assert bytes(re_data) == bytes(msg_data)
+        bit_str_msg_sid = BitString(msg_sid.to_bytes(4, 'big'), MESSAGE_SID.length)
+        bit_str_msg_sid.pop(MESSAGE_PRIO.length)
+        bit_str_msg_sid.pop(MESSAGE_TYPE.length)
+        bit_str_msg_sid.pop(BOARD_TYPE_ID.length)
+        bit_str_msg_sid.pop(BOARD_INST_ID.length)
+        assert MESSAGE_METADATA.decode(bit_str_msg_sid.pop(MESSAGE_METADATA.length)) == 0xFF
 
     def test_parsley_error_carries_msg_prio(self):
-        # ParsleyError must include msg_prio so consumers branching on error
-        # can still observe priority. Trigger an error by giving a bad SID
-        # that decodes msg_prio successfully but fails on msg_type.
         bit_sid = BitString()
         bit_sid.push(*MESSAGE_PRIO.encode('LOW'))
         bit_sid.push(b'\x7F', MESSAGE_TYPE.length)  # 0x7F is not a known msg_type

--- a/tests/test_parsley.py
+++ b/tests/test_parsley.py
@@ -121,12 +121,6 @@ class TestParsley:
 
         assert res == expected_res
         
-    # ── Error-path shape invariant ──────────────────────────────────────
-    # All `parsley.parse()` error returns MUST carry the same triage fields
-    # as a success return. Previously these tests only checked
-    # `'error' in res['data']`, which let bug #B2 hide: the error dict was
-    # silently dropping `msg_prio` and `msg_metadata` for the entire
-    # 2026.3 cycle and no test failed. The shape check below catches that.
     _EXPECTED_ERROR_KEYS = {
         'msg_prio', 'board_type_id', 'board_inst_id',
         'msg_type', 'msg_metadata', 'data'
@@ -252,8 +246,6 @@ class TestParsley:
         assert bit_len == 70
         
     def test_format_line(self):
-        # Structural check (see test_parse_to_object.py:test_format_line for
-        # why substring-only assertions are insufficient here).
         parsed_data = {
             'msg_prio': 'HIGH',
             'msg_type': 'GENERAL_BOARD_STATUS',

--- a/tests/test_parsley.py
+++ b/tests/test_parsley.py
@@ -121,24 +121,43 @@ class TestParsley:
 
         assert res == expected_res
         
+    # ── Error-path shape invariant ──────────────────────────────────────
+    # All `parsley.parse()` error returns MUST carry the same triage fields
+    # as a success return. Previously these tests only checked
+    # `'error' in res['data']`, which let bug #B2 hide: the error dict was
+    # silently dropping `msg_prio` and `msg_metadata` for the entire
+    # 2026.3 cycle and no test failed. The shape check below catches that.
+    _EXPECTED_ERROR_KEYS = {
+        'msg_prio', 'board_type_id', 'board_inst_id',
+        'msg_type', 'msg_metadata', 'data'
+    }
+
+    def _assert_error_shape(self, res):
+        assert set(res.keys()) == self._EXPECTED_ERROR_KEYS, (
+            f"error dict shape regressed: missing {self._EXPECTED_ERROR_KEYS - set(res.keys())}, "
+            f"extra {set(res.keys()) - self._EXPECTED_ERROR_KEYS}"
+        )
+        assert set(res['data'].keys()) == {'msg_data', 'error'}
+        assert res['data']['error'].startswith('error:')
+
     def test_parse_bad_msg_type(self):
         msg_sid = b'\x00\x00'
         msg_data = b'\xAB\xCD\xEF\x00'
         res = parsley.parse(msg_sid, msg_data)
-        assert 'error' in res['data']
-    
+        self._assert_error_shape(res)
+
     def test_parse_empty(self):
         msg_sid = b''
         msg_data = b''
         res = parsley.parse(msg_sid, msg_data)
-        assert 'error' in res['data'] 
-        
+        self._assert_error_shape(res)
+
     def test_parse_messed_up_SID(self):
         msg_sid = b'\xFF\xFF\xFF\xFF'  # Invalid SID
         msg_data = b'\x00\x00\x00\x00'  # Dummy data
         res = parsley.parse(msg_sid, msg_data)
-        assert 'error' in res['data']
-        
+        self._assert_error_shape(res)
+
     def test_parse_bad_board_type_id(self):
         # manually build message since using BOARD_TYPE_ID from message_definitions will throw an error for b'\x1F' as it is invalid
         bit_msg_sid = BitString()
@@ -150,7 +169,11 @@ class TestParsley:
         msg_sid = bit_msg_sid.pop(MESSAGE_SID.length)
 
         res = parsley.parse(msg_sid, b'')
-        assert '0x' in res['board_type_id']
+        # board_type_id 0x1F isn't in the enum → parser hexifies; assert both
+        # the hex shape AND that no other field got blanked by the fallback.
+        assert res['board_type_id'].startswith('0x')
+        assert res['msg_prio'] == 'LOW'
+        assert res['board_inst_id'] == 'ANY'  # 0x00 decoded fine
 
     def test_parse_bad_msg_data(self):
         msg_sid = utilities.create_msg_sid_from_strings('MEDIUM', 'ALT_ARM_STATUS', '0', 'ALTIMETER', 'ANY')
@@ -159,8 +182,12 @@ class TestParsley:
         msg_data = b'\x00\x00\x01'  # truncated, missing drogue_v and main_v
 
         res = parsley.parse(msg_sid, msg_data)
-        assert 'error' in res['data']
-        
+        self._assert_error_shape(res)
+        # Even on a payload-decode failure, the SID-level fields must survive.
+        assert res['msg_prio'] == 'MEDIUM'
+        assert res['board_type_id'] == 'ALTIMETER'
+        assert res['board_inst_id'] == 'ANY'
+
     def test_bad_board_instance(self):
         # manually build message since BOARD_INST_ID.encode() will throw an error for b'\x1F'
         bit_msg_sid = BitString()
@@ -172,7 +199,9 @@ class TestParsley:
         msg_sid = bit_msg_sid.pop(MESSAGE_SID.length)
 
         res = parsley.parse(msg_sid, b'')
-        assert '0x' in res['board_inst_id']
+        assert res['board_inst_id'].startswith('0x')
+        assert res['msg_prio'] == 'LOW'
+        assert res['board_type_id'] == 'GPS'
         
     def test_parse_bitstring(self):
         bit_str = BitString()
@@ -223,21 +252,35 @@ class TestParsley:
         assert bit_len == 70
         
     def test_format_line(self):
+        # Structural check (see test_parse_to_object.py:test_format_line for
+        # why substring-only assertions are insufficient here).
         parsed_data = {
             'msg_prio': 'HIGH',
             'msg_type': 'GENERAL_BOARD_STATUS',
             'board_type_id': 'RLCS_RELAY',
             'board_inst_id': 'ROCKET',
+            'msg_metadata': 0,
             'data': {
                 'time': 1.234,
                 'board_error_bitfield': 'E_5V_OVER_VOLTAGE|E_5V_EFUSE_FAULT'
             }
         }
         line = parsley.format_line(parsed_data)
-        # MSG_PRIO_LEN=7 (HIGHEST), MSG_TYPE_LEN=20 (GENERAL_BOARD_STATUS),
-        # BOARD_TYPE_ID_LEN=10 (RLCS_RELAY), BOARD_INST_ID_LEN=15 (RA_STRATOLOGGER)
-        expected_line = '[ HIGH    GENERAL_BOARD_STATUS   RLCS_RELAY ROCKET          ] time: 1.234 board_error_bitfield: E_5V_OVER_VOLTAGE|E_5V_EFUSE_FAULT'
-        assert line == expected_line
+        header, body = utilities.split_format_line(line)
+        assert header == ['HIGH', 'GENERAL_BOARD_STATUS', 'RLCS_RELAY', 'ROCKET', '0']
+        assert body == {'time': '1.234', 'board_error_bitfield': 'E_5V_OVER_VOLTAGE|E_5V_EFUSE_FAULT'}
+
+    def test_format_line_includes_sensor_metadata(self):
+        parsed_data = {
+            'msg_prio': 'LOW',
+            'msg_type': 'SENSOR_ANALOG16',
+            'board_type_id': 'LOGGER',
+            'board_inst_id': 'ROCKET',
+            'msg_metadata': 'SENSOR_PT_CHANNEL_1',
+            'data': {'time': 22.473, 'value': 13923},
+        }
+        line = parsley.format_line(parsed_data)
+        assert 'SENSOR_PT_CHANNEL_1' in line
         
     def test_encode_data(self):
         parsed_data = {

--- a/tests/test_parsley_message.py
+++ b/tests/test_parsley_message.py
@@ -5,6 +5,7 @@ from parsley.parsley_message import ParsleyObject, ParsleyError
 
 def test_parsley_error_getitem():
     err = ParsleyError(
+        msg_prio='HIGH',
         board_type_id='ANY',
         board_inst_id='GROUND',
         msg_type='RESET_CMD',
@@ -13,6 +14,7 @@ def test_parsley_error_getitem():
         error='something went wrong'
     )
 
+    assert err['msg_prio'] == 'HIGH'
     assert err['board_type_id'] == 'ANY'
     assert err['board_inst_id'] == 'GROUND'
     assert err['msg_type'] == 'RESET_CMD'
@@ -39,16 +41,72 @@ def test_parsley_object_getitem():
     assert obj['data'] == {}
 
 
-def test_parsley_object_unknown_prio_accepted():
+def test_parsley_object_unknown_prio_raises():
+    # The parser will never emit a msg_prio outside mt.msg_prio (the 2-bit
+    # MESSAGE_PRIO enum is fully populated), so accepting one is a sign of
+    # caller-side breakage (e.g. forgetting to decode and passing the raw
+    # hex string '0x03'). Strict validation surfaces these bugs early.
+    with pytest.raises(ValidationError):
+        ParsleyObject(
+            board_type_id='ANY',
+            board_inst_id='GROUND',
+            msg_prio='0x03',
+            msg_type='RESET_CMD',
+            msg_metadata=0,
+            data={}
+        )
+
+
+def test_parsley_object_metadata_string_must_match_msg_type_enum():
+    # SENSOR_ANALOG16 uses analog_sensor_id; a name from actuator_id is invalid.
+    with pytest.raises(ValidationError):
+        ParsleyObject(
+            board_type_id='LOGGER',
+            board_inst_id='ROCKET',
+            msg_prio='LOW',
+            msg_type='SENSOR_ANALOG16',
+            msg_metadata='ACTUATOR_OX_INJECTOR_VALVE',  # wrong enum for this msg_type
+            data={'time': 0.0, 'value': 0},
+        )
+
+
+def test_parsley_object_metadata_string_rejected_for_numeric_msg_type():
+    # RESET_CMD has a generic Numeric metadata byte (no enum). A string is invalid.
+    with pytest.raises(ValidationError):
+        ParsleyObject(
+            board_type_id='ANY',
+            board_inst_id='GROUND',
+            msg_prio='HIGH',
+            msg_type='RESET_CMD',
+            msg_metadata='SENSOR_PT_CHANNEL_1',
+            data={}
+        )
+
+
+def test_parsley_object_metadata_int_always_allowed_in_range():
+    # The parser falls back to a raw int byte for corrupt-but-known frames.
+    # Validation must NOT reject that, or the corruption-fallback path breaks.
     obj = ParsleyObject(
-        board_type_id='ANY',
-        board_inst_id='GROUND',
-        msg_prio='0x03',
-        msg_type='RESET_CMD',
-        msg_metadata=0,
-        data={}
+        board_type_id='LOGGER',
+        board_inst_id='ROCKET',
+        msg_prio='LOW',
+        msg_type='SENSOR_ANALOG16',
+        msg_metadata=250,  # not a real analog_sensor_id, but int fallback is OK
+        data={'time': 0.0, 'value': 0},
     )
-    assert obj['msg_prio'] == '0x03'
+    assert obj['msg_metadata'] == 250
+
+
+def test_parsley_object_metadata_string_matching_enum_accepted():
+    obj = ParsleyObject(
+        board_type_id='LOGGER',
+        board_inst_id='ROCKET',
+        msg_prio='LOW',
+        msg_type='SENSOR_ANALOG16',
+        msg_metadata='SENSOR_PT_CHANNEL_1',
+        data={'time': 0.0, 'value': 0},
+    )
+    assert obj['msg_metadata'] == 'SENSOR_PT_CHANNEL_1'
 
 
 def test_parsley_object_empty_prio_raises():

--- a/tests/test_parsley_message.py
+++ b/tests/test_parsley_message.py
@@ -42,10 +42,6 @@ def test_parsley_object_getitem():
 
 
 def test_parsley_object_unknown_prio_raises():
-    # The parser will never emit a msg_prio outside mt.msg_prio (the 2-bit
-    # MESSAGE_PRIO enum is fully populated), so accepting one is a sign of
-    # caller-side breakage (e.g. forgetting to decode and passing the raw
-    # hex string '0x03'). Strict validation surfaces these bugs early.
     with pytest.raises(ValidationError):
         ParsleyObject(
             board_type_id='ANY',
@@ -58,20 +54,18 @@ def test_parsley_object_unknown_prio_raises():
 
 
 def test_parsley_object_metadata_string_must_match_msg_type_enum():
-    # SENSOR_ANALOG16 uses analog_sensor_id; a name from actuator_id is invalid.
     with pytest.raises(ValidationError):
         ParsleyObject(
             board_type_id='LOGGER',
             board_inst_id='ROCKET',
             msg_prio='LOW',
             msg_type='SENSOR_ANALOG16',
-            msg_metadata='ACTUATOR_OX_INJECTOR_VALVE',  # wrong enum for this msg_type
+            msg_metadata='ACTUATOR_OX_INJECTOR_VALVE',
             data={'time': 0.0, 'value': 0},
         )
 
 
 def test_parsley_object_metadata_string_rejected_for_numeric_msg_type():
-    # RESET_CMD has a generic Numeric metadata byte (no enum). A string is invalid.
     with pytest.raises(ValidationError):
         ParsleyObject(
             board_type_id='ANY',
@@ -84,14 +78,12 @@ def test_parsley_object_metadata_string_rejected_for_numeric_msg_type():
 
 
 def test_parsley_object_metadata_int_always_allowed_in_range():
-    # The parser falls back to a raw int byte for corrupt-but-known frames.
-    # Validation must NOT reject that, or the corruption-fallback path breaks.
     obj = ParsleyObject(
         board_type_id='LOGGER',
         board_inst_id='ROCKET',
         msg_prio='LOW',
         msg_type='SENSOR_ANALOG16',
-        msg_metadata=250,  # not a real analog_sensor_id, but int fallback is OK
+        msg_metadata=250,
         data={'time': 0.0, 'value': 0},
     )
     assert obj['msg_metadata'] == 250

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -25,13 +25,7 @@ def create_msg_sid_from_strings(priority_str: str, msg_type_str: str, metadata_s
 
 
 def split_format_line(line: str) -> tuple[list[str], dict[str, str]]:
-    """Parse `format_line` output back into (header_fields, body_dict).
-
-    Structural decomposition for tests: catches dropped/reordered fields
-    without being brittle about column-padding widths. Header is the
-    bracketed `[ prio type btype binst metadata ]` prefix; body is the
-    trailing ` key: value key: value ...` payload.
-    """
+    """Parse format_line output back into (header_fields, body_dict)."""
     bracket, sep, body = line.partition(']')
     assert sep == ']', f"format_line output missing closing bracket: {line!r}"
     header_fields = bracket.lstrip('[ ').split()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -22,3 +22,20 @@ def create_msg_sid_from_strings(priority_str: str, msg_type_str: str, metadata_s
     bit_msg_sid.push(metadata_bits, MESSAGE_METADATA.length)
     msg_sid = bit_msg_sid.pop(MESSAGE_SID.length)
     return msg_sid
+
+
+def split_format_line(line: str) -> tuple[list[str], dict[str, str]]:
+    """Parse `format_line` output back into (header_fields, body_dict).
+
+    Structural decomposition for tests: catches dropped/reordered fields
+    without being brittle about column-padding widths. Header is the
+    bracketed `[ prio type btype binst metadata ]` prefix; body is the
+    trailing ` key: value key: value ...` payload.
+    """
+    bracket, sep, body = line.partition(']')
+    assert sep == ']', f"format_line output missing closing bracket: {line!r}"
+    header_fields = bracket.lstrip('[ ').split()
+    parts = body.strip().split()
+    assert len(parts) % 2 == 0, f"format_line body has unpaired key/value tokens: {body!r}"
+    body_dict = {parts[i].rstrip(':'): parts[i + 1] for i in range(0, len(parts), 2)}
+    return header_fields, body_dict


### PR DESCRIPTION

Trying to root out all pre 2026.3 remnants to avoid silent bugs. 

Changes: 
- format_line now prints msg_metadata, fixes bug reported by Jason
- encode_data can now let parse_msg_metadata fall back to a raw int byte
- ParsleyError also features msg_prio
- Strict msg_prio validation in pydantic
-  Cross-checked msg_metadata validation in pydantic

Tests
- Rewrote tests to ensure that a regression is not possible by adding a new split_format_line to split the output line and new tests to assert against contents as opposed to the string verbatim. 
- New tests

<img width="1235" height="213" alt="Screenshot 2026-05-20 at 8 09 30 PM" src="https://github.com/user-attachments/assets/237d0a39-ecd5-45f6-977e-6e4dc8e37223" />



<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/parsley/66)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Message metadata is included in formatted output, consistently sized/aligned, and validated against message types.
  * Error reports now include message priority and metadata alongside existing fields.

* **Bug Fixes**
  * Encoding preserves raw metadata values for numeric enum cases and avoids blanking SID-derived fields on failures.
  * Validation for message priority and metadata is stricter to reject invalid inputs.

* **Tests**
  * Added and tightened tests for formatting, metadata handling, encoding behavior, and standardized error shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->