### PR TITLE
Add to_flat_dict() for flattening parsley messages

### DIFF
--- a/src/parsley/parsley_message.py
+++ b/src/parsley/parsley_message.py
@@ -99,7 +99,6 @@ class ParsleyObject(BaseModel, Generic[T]):
 
     def to_flat_dict(self) -> dict[str, Any]:
         """Flatten data fields into {'BoardType/BoardInstance/MsgType/MsgMetadata/field': value} pairs."""
-        dumped = self.model_dump()
-        nested_data = dumped.pop("data", {}) or {}
-        prefix = _flatten_prefix(dumped["board_type_id"], dumped["board_inst_id"], dumped["msg_type"], dumped["msg_metadata"])
+        nested_data = self.data or {}
+        prefix = _flatten_prefix(self.board_type_id, self.board_inst_id, self.msg_type, self.msg_metadata)
         return {f"{prefix}/{field}": value for field, value in nested_data.items()}

--- a/src/parsley/parsley_message.py
+++ b/src/parsley/parsley_message.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, asdict
-from typing import Generic, TypeVar
+from typing import Any, Generic, TypeVar
 from pydantic import BaseModel, field_validator, model_validator
 import parsley.message_types as mt
 from parsley.message_definitions import CAN_MESSAGE
@@ -12,6 +12,10 @@ BoardInstID = str
 MsgPrio = str
 MsgType = str
 MsgMetadata = int | str
+
+def _flatten_prefix(board_type_id: BoardTypeID, board_inst_id: BoardInstID, msg_type: MsgType, msg_metadata: MsgMetadata) -> str:
+    """Build the 'BoardType/BoardInstance/MsgType/MsgMetadata' prefix shared by to_flat_dict() on ParsleyObject and ParsleyError."""
+    return f"{board_type_id}/{board_inst_id}/{msg_type}/{msg_metadata}"
 
 @dataclass
 class ParsleyError():
@@ -26,7 +30,15 @@ class ParsleyError():
 
     def __getitem__(self, key: str):
         return asdict(self)[key]
-    
+
+    def to_flat_dict(self) -> dict[str, Any]:
+        """Flatten into {'BoardType/BoardInstance/MsgType/MsgMetadata/field': value} pairs."""
+        prefix = _flatten_prefix(self.board_type_id, self.board_inst_id, self.msg_type, self.msg_metadata)
+        return {
+            f"{prefix}/msg_data": self.msg_data,
+            f"{prefix}/error": self.error,
+        }
+
 class ParsleyObject(BaseModel, Generic[T]):
     """
     Dataclass to store parsed CAN message data.
@@ -84,3 +96,10 @@ class ParsleyObject(BaseModel, Generic[T]):
 
     def __getitem__(self, key: str):
         return self.model_dump()[key]
+
+    def to_flat_dict(self) -> dict[str, Any]:
+        """Flatten data fields into {'BoardType/BoardInstance/MsgType/MsgMetadata/field': value} pairs."""
+        dumped = self.model_dump()
+        nested_data = dumped.pop("data", {}) or {}
+        prefix = _flatten_prefix(dumped["board_type_id"], dumped["board_inst_id"], dumped["msg_type"], dumped["msg_metadata"])
+        return {f"{prefix}/{field}": value for field, value in nested_data.items()}

--- a/tests/test_parsley_message.py
+++ b/tests/test_parsley_message.py
@@ -138,3 +138,75 @@ def test_parsley_object_invalid_type_raises():
             msg_metadata=0,
             data={}
         )
+
+
+def test_parsley_object_to_flat_dict():
+    obj = ParsleyObject(
+        board_type_id='LOGGER',
+        board_inst_id='ROCKET',
+        msg_prio='LOW',
+        msg_type='SENSOR_ANALOG16',
+        msg_metadata='SENSOR_PT_CHANNEL_1',
+        data={'time': 0.5, 'value': 100},
+    )
+
+    assert obj.to_flat_dict() == {
+        'LOGGER/ROCKET/SENSOR_ANALOG16/SENSOR_PT_CHANNEL_1/time': 0.5,
+        'LOGGER/ROCKET/SENSOR_ANALOG16/SENSOR_PT_CHANNEL_1/value': 100,
+    }
+
+
+def test_parsley_object_to_flat_dict_empty_data():
+    obj = ParsleyObject(
+        board_type_id='ANY',
+        board_inst_id='GROUND',
+        msg_prio='HIGH',
+        msg_type='RESET_CMD',
+        msg_metadata=0,
+        data={}
+    )
+
+    assert obj.to_flat_dict() == {}
+
+
+def test_parsley_object_to_flat_dict_avoids_cross_msg_type_collision():
+    # GPS_TIMESTAMP and GPS_LATITUDE share the same board, same (numeric) metadata,
+    # and both have a 'mins' data field -- msg_type must be in the key or these collide.
+    timestamp = ParsleyObject(
+        board_type_id='GPS',
+        board_inst_id='ROCKET',
+        msg_prio='LOW',
+        msg_type='GPS_TIMESTAMP',
+        msg_metadata=5,
+        data={'hrs': 23, 'mins': 59, 'secs': 44, 'dsecs': 26},
+    )
+    latitude = ParsleyObject(
+        board_type_id='GPS',
+        board_inst_id='ROCKET',
+        msg_prio='LOW',
+        msg_type='GPS_LATITUDE',
+        msg_metadata=5,
+        data={'degs': 43, 'mins': 28, 'dmins': 100, 'direction': 'N'},
+    )
+
+    combined = {**timestamp.to_flat_dict(), **latitude.to_flat_dict()}
+
+    assert combined['GPS/ROCKET/GPS_TIMESTAMP/5/mins'] == 59
+    assert combined['GPS/ROCKET/GPS_LATITUDE/5/mins'] == 28
+
+
+def test_parsley_error_to_flat_dict():
+    err = ParsleyError(
+        msg_prio='HIGH',
+        board_type_id='GPS',
+        board_inst_id='ROCKET',
+        msg_type='GPS_ALTITUDE',
+        msg_metadata=0x42,
+        msg_data='0xFFEEDDCC',
+        error='ChecksumMismatch: GPS packet corrupted'
+    )
+
+    assert err.to_flat_dict() == {
+        'GPS/ROCKET/GPS_ALTITUDE/66/msg_data': '0xFFEEDDCC',
+        'GPS/ROCKET/GPS_ALTITUDE/66/error': 'ChecksumMismatch: GPS packet corrupted',
+    }


### PR DESCRIPTION
Adds `to_flat_dict()` to both `ParsleyObject` and `ParsleyError`, flattening a message's data fields into `BoardType/BoardInstance/MsgType/MsgMetadata/field` columns for CSV export

Didn't just use `model.dump() `because it gives us everything even things we don't need. Custom field avoids this extra work.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/parsley/70)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated message flattening so nested fields are now returned with consistent, fully qualified keys.
  * Error objects now use the same flattened format, making message data easier to consume.
* **Bug Fixes**
  * Prevented key collisions when similar field names appear across different message types.
  * Empty nested data now returns an empty mapping as expected.
* **Tests**
  * Added coverage for flattened output, empty payloads, and collision-safe key generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->