### PR TITLE
Fix reset cmd board id collision

### DIFF
--- a/src/parsley/message_definitions.py
+++ b/src/parsley/message_definitions.py
@@ -16,9 +16,9 @@ MESSAGE_SID = Enum('msg_sid', MESSAGE_PRIO.length + MESSAGE_TYPE.length + BOARD_
 # but BOARD_ID is still here so that Omnibus has all the fields it needs when creating messages to send
 MESSAGES = {
     'GENERAL_BOARD_STATUS':  [MESSAGE_PRIO, BOARD_TYPE_ID, BOARD_INST_ID, MESSAGE_METADATA, TIMESTAMP_2, Bitfield('board_error_bitfield', 32, "E_NOMINAL", mt.board_error_bitfield_offset)],
-    'RESET_CMD':             [MESSAGE_PRIO, BOARD_TYPE_ID, BOARD_INST_ID, MESSAGE_METADATA, TIMESTAMP_2, Enum('board_type_id', 8, mt.board_type_id), Enum('board_inst_id', 8, mt.board_inst_id)],
+    'RESET_CMD':             [MESSAGE_PRIO, BOARD_TYPE_ID, BOARD_INST_ID, MESSAGE_METADATA, TIMESTAMP_2, Enum('target_board_type_id', 8, mt.board_type_id), Enum('target_board_inst_id', 8, mt.board_inst_id)],
     'DEBUG_RAW':             [MESSAGE_PRIO, BOARD_TYPE_ID, BOARD_INST_ID, MESSAGE_METADATA, TIMESTAMP_2, ASCII('string', 48)],
-    'CONFIG_SET':            [MESSAGE_PRIO, BOARD_TYPE_ID, BOARD_INST_ID, MESSAGE_METADATA, TIMESTAMP_2, Enum('board_type_id', 8, mt.board_type_id), Enum('board_inst_id', 8, mt.board_inst_id), Numeric('config_id', 16), Numeric('config_value', 16)],
+    'CONFIG_SET':            [MESSAGE_PRIO, BOARD_TYPE_ID, BOARD_INST_ID, MESSAGE_METADATA, TIMESTAMP_2, Enum('target_board_type_id', 8, mt.board_type_id), Enum('target_board_inst_id', 8, mt.board_inst_id), Numeric('config_id', 16), Numeric('config_value', 16)],
     'CONFIG_STATUS':         [MESSAGE_PRIO, BOARD_TYPE_ID, BOARD_INST_ID, MESSAGE_METADATA, TIMESTAMP_2, Numeric('config_id', 16), Numeric('config_value', 16)],
     'ACTUATOR_CMD':          [MESSAGE_PRIO, BOARD_TYPE_ID, BOARD_INST_ID, Enum('msg_metadata', 8, mt.actuator_id), TIMESTAMP_2, Enum('cmd_state', 8, mt.actuator_state)],
     'ACTUATOR_STATUS':       [MESSAGE_PRIO, BOARD_TYPE_ID, BOARD_INST_ID, Enum('msg_metadata', 8, mt.actuator_id), TIMESTAMP_2, Enum('cmd_state', 8, mt.actuator_state), Enum('curr_state', 8, mt.actuator_state)],

--- a/tests/test_message_definitions.py
+++ b/tests/test_message_definitions.py
@@ -27,12 +27,19 @@ class TestCANMessage:
         res = parsley.parse_fields(bit_str2, MESSAGES["GENERAL_BOARD_STATUS"][4:]) # [4:] to skip prio, type, inst
         assert res["board_error_bitfield"] == 'E_5V_OVER_CURRENT|E_5V_OVER_VOLTAGE|E_12V_OVER_CURRENT'
 
+    def test_payload_fields_never_shadow_header_fields(self):
+        header_names = {'msg_prio', 'msg_type', 'board_type_id', 'board_inst_id', 'msg_metadata'}
+        for msg_type, fields in MESSAGES.items():
+            for field in fields[4:]:  # [4:] skips the header fields
+                assert field.name not in header_names, \
+                    f"{msg_type} payload field '{field.name}' collides with a header field"
+
     def test_reset_cmd(self, bit_str2):
         bit_str2.push(b"\x08\x00", 16) # 0x08 (ALTIMETER), 0x00 (ANY)
         res = parsley.parse_fields(bit_str2, MESSAGES["RESET_CMD"][4:])
 
-        assert res["board_type_id"] == 'ALTIMETER'
-        assert res["board_inst_id"] == 'ANY'
+        assert res["target_board_type_id"] == 'ALTIMETER'
+        assert res["target_board_inst_id"] == 'ANY'
 
     def test_debug_raw(self, bit_str2):
         bit_str2.push(b"rawmsg", 48)
@@ -45,8 +52,8 @@ class TestCANMessage:
         bit_str2.push(b"\x01\x02\x03\x04\x05\x06", 48)
         res = parsley.parse_fields(bit_str2, MESSAGES["CONFIG_SET"][4:])
 
-        assert res["board_type_id"] == 'INJECTOR'
-        assert res["board_inst_id"] == 'ROCKET'
+        assert res["target_board_type_id"] == 'INJECTOR'
+        assert res["target_board_inst_id"] == 'ROCKET'
         assert res["config_id"] == 0x0304
         assert res["config_value"] == 0x0506
 


### PR DESCRIPTION
Very simple fix, main issue was that the names collided and it overwrote. Names are different now


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/parsley/71)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added flattened key-value output for parsed messages and parsing errors, including board, message, metadata, and payload details.
  * Improved key uniqueness for messages with overlapping payload fields.

* **Bug Fixes**
  * Renamed reset and configuration target board fields for clearer identification.
  * Prevented payload fields from conflicting with message header fields.

* **Tests**
  * Added coverage for flattened outputs, empty payloads, error details, and field-name collision prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->